### PR TITLE
reverse envmap x y direction

### DIFF
--- a/src/renderer/glsl/chunks/envmap.glsl
+++ b/src/renderer/glsl/chunks/envmap.glsl
@@ -7,6 +7,12 @@ export default function(params) {
 uniform sampler2D envmap;
 uniform sampler2D envmapDistribution;
 
+vec2 cartesianToEquirect(vec3 d) {
+  float phi = mod(atan(-d.z, -d.x), TWOPI);
+  float theta = acos(d.y);
+  return vec2(phi * 0.5 * INVPI, theta * INVPI);
+}
+
 float getEnvmapV(float u, out int vOffset, out float pdf) {
   ivec2 size = textureSize(envmap, 0);
 
@@ -70,7 +76,7 @@ vec3 sampleEnvmap(vec2 random, out vec2 uv, out float pdf) {
   float cosPhi = cos(phi);
   float sinPhi = sin(phi);
 
-  vec3 dir = vec3(sinTheta * cosPhi, cosTheta, sinTheta * sinPhi);
+  vec3 dir = vec3(-sinTheta * cosPhi, cosTheta, -sinTheta * sinPhi);
 
   pdf = partialPdf.x * partialPdf.y * INVPI2 / (2.0 * sinTheta);
 
@@ -91,21 +97,18 @@ float envmapPdf(vec2 uv) {
 }
 
 vec3 sampleEnvmapFromDirection(vec3 d) {
-  float theta = acos(d.y) * INVPI;
-  float phi = mod(atan(d.z, d.x), TWOPI) * 0.5 * INVPI;
-
-  return textureLinear(envmap, vec2(phi, theta)).rgb;
+  vec2 uv = cartesianToEquirect(d);
+  return textureLinear(envmap, uv).rgb;
 }
 
 // debugging function
 vec3 sampleEnvmapDistributionFromDirection(vec3 d) {
   vec2 size = vec2(textureSize(envmap, 0));
 
-  float theta = acos(d.y) * INVPI;
-  float phi = mod(atan(d.z, d.x), TWOPI) * 0.5 * INVPI;
+  vec2 uv = cartesianToEquirect(d);
 
-  float u = texelFetch(envmapDistribution, ivec2(1.0 + phi * size.x, theta * size.y), 0).g;
-  float v = texelFetch(envmapDistribution, ivec2(0, theta * size.y), 0).g;
+  float u = texelFetch(envmapDistribution, ivec2(1.0 + uv.x * size.x, uv.y * size.y), 0).g;
+  float v = texelFetch(envmapDistribution, ivec2(0, uv.y * size.y), 0).g;
 
   return vec3(u * v);
 }

--- a/src/renderer/glsl/chunks/sampleGlassMicrofacet.glsl
+++ b/src/renderer/glsl/chunks/sampleGlassMicrofacet.glsl
@@ -119,9 +119,8 @@ vec3 glassImportanceSampleMaterial(SurfaceInteraction si, vec3 viewDir, bool lig
      return li;
   }
 
-  float phi = mod(atan(lightDir.z, lightDir.x) * 0.5 * INVPI, 1.0);
-  float theta = acos(lightDir.y) * INVPI;
-  float lightPdf = envmapPdf(phi, theta);
+  vec2 uv = cartesianToEquirect(lightDir);
+  float lightPdf = envmapPdf(uv);
 
   vec3 irr = textureLinear(envmap, vec2(phi, theta)).rgb;
 

--- a/src/renderer/glsl/chunks/sampleMaterial.glsl
+++ b/src/renderer/glsl/chunks/sampleMaterial.glsl
@@ -62,9 +62,7 @@ vec3 importanceSampleMaterial(SurfaceInteraction si, vec3 viewDir, bool lastBoun
     }
   }
 
-  float phi = mod(atan(lightDir.z, lightDir.x), TWOPI);
-  float theta = acos(lightDir.y);
-  vec2 uv = vec2(0.5 * phi * INVPI, theta * INVPI);
+  vec2 uv = cartesianToEquirect(lightDir);
 
   float lightPdf = envmapPdf(uv);
 

--- a/src/renderer/glsl/chunks/sampleShadowCatcher.glsl
+++ b/src/renderer/glsl/chunks/sampleShadowCatcher.glsl
@@ -59,9 +59,7 @@ float importanceSampleMaterialShadowCatcher(SurfaceInteraction si, vec3 viewDir,
     occluded = 0.0;
   }
 
-  float phi = mod(atan(lightDir.z, lightDir.x), TWOPI);
-  float theta = acos(lightDir.y);
-  vec2 uv = vec2(0.5 * phi * INVPI, theta * INVPI);
+  vec2 uv = cartesianToEquirect(lightDir);
 
   float lightPdf = envmapPdf(uv);
 


### PR DESCRIPTION
## Brief Description
This PR rotates the orientation of the Environment Light by 180 degrees. Since Environment Light is a new type of light, there's no inherently correct orientation. However, the  [EquirectangularToCubemap](https://github.com/mrdoob/three.js/blob/dev/examples/js/loaders/EquirectangularToCubeGenerator.js) class provided by Three.js generates cubemaps that are arbitrarily opposite of the orientation of the Environment Light.

This PR rotates the Environment Light so that equirectangular maps provided to both the WebGLRenderer (by using EquirectangularToCubeMap) and RayTracingRenderer are the same orientation. This should address the issue brought up in https://github.com/hoverinc/ray-tracing-renderer/pull/3.

In addition, I've cleaned up the coordinate conversion code by moving it into its own function.

## Image(s) or GIFs (if applicable)
TODO or DELETE

## Pull Request Guidelines
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] I have added pull requests labels which describe my contribution.
- [x] All existing tests passed.
    - [ ] I have added tests to cover my changes, of which pass.
- [x] I have [compared](https://github.com/hoverinc/ray-tracing-renderer/wiki/Contributing#comparing-changes) the render output of my branch to `master`.
- [x] My code has passed the ESLint configuration for this project.
- [ ] My change requires modifications to the documentation.
    - [ ] I have updated the documentation accordingly.
