### PR TITLE
Automatically define GLSL constants

### DIFF
--- a/src/renderer/glsl/chunks/intersect.glsl
+++ b/src/renderer/glsl/chunks/intersect.glsl
@@ -1,16 +1,6 @@
 export default function(params) {
   return `
 
-#define BVH_COLUMNS ${params.bvhColumnsLog}
-#define INDEX_COLUMNS ${params.indexColumnsLog}
-#define VERTEX_COLUMNS ${params.vertexColumnsLog}
-#define STACK_SIZE ${params.maxBvhDepth}
-#define NUM_TRIS ${params.numTris}
-#define NUM_MATERIALS ${params.numMaterials}
-${params.numDiffuseMaps > 0 ? `#define NUM_DIFFUSE_MAPS ${params.numDiffuseMaps}` : ''}
-${params.numNormalMaps > 0 ? `#define NUM_NORMAL_MAPS ${params.numNormalMaps}` : ''}
-${params.numPbrMaps > 0 ? `#define NUM_PBR_MAPS ${params.numPbrMaps}` : ''}
-
 uniform highp isampler2D indices;
 uniform sampler2D positions;
 uniform sampler2D normals;
@@ -26,7 +16,7 @@ uniform Materials {
   #endif
 
   #if defined(NUM_DIFFUSE_MAPS) || defined(NUM_NORMAL_MAPS)
-    vec4 diffuseNormalMapSize[${Math.max(params.numDiffuseMaps, params.numNormalMaps)}];
+    vec4 diffuseNormalMapSize[${Math.max(params.NUM_DIFFUSE_MAPS, params.NUM_NORMAL_MAPS)}];
   #endif
 
   #if defined(NUM_PBR_MAPS)

--- a/src/renderer/glsl/chunks/random.glsl
+++ b/src/renderer/glsl/chunks/random.glsl
@@ -22,8 +22,6 @@ uint xorshift(uint x) {
   return x;
 }
 
-#define STRATA_DIMENSIONS ${params.strataDimensions}
-
 uniform float seed; // Random number [0, 1)
 uniform float strataStart[STRATA_DIMENSIONS];
 uniform float strataSize;

--- a/src/renderer/glsl/chunks/textureLinear.glsl
+++ b/src/renderer/glsl/chunks/textureLinear.glsl
@@ -3,8 +3,6 @@
 export default function(params) {
   return `
 
-  ${params.OES_texture_float_linear ? '#define OES_texture_float_linear' : ''}
-
   vec4 textureLinear(sampler2D map, vec2 uv) {
     #ifdef OES_texture_float_linear
       return texture(map, uv);

--- a/src/renderer/glsl/rayTrace.frag
+++ b/src/renderer/glsl/rayTrace.frag
@@ -8,13 +8,15 @@ import sampleMaterial from './chunks/sampleMaterial.glsl';
 import sampleShadowCatcher from './chunks/sampleShadowCatcher.glsl';
 import sampleGlass from './chunks/sampleGlassSpecular.glsl';
 // import sampleGlass from './chunks/sampleGlassMicrofacet.glsl';
-import { unrollLoop } from '../glslUtil';
+import { unrollLoop, addDefines } from '../glslUtil';
 
 export default function(params) {
   return `#version 300 es
 
 precision mediump float;
 precision mediump int;
+
+${addDefines(params)}
 
 #define PI 3.14159265359
 #define TWOPI 6.28318530718
@@ -41,10 +43,6 @@ const float R0 = (1.0 - IOR) * (1.0 - IOR)  / ((1.0 + IOR) * (1.0 + IOR));
 
 // https://www.w3.org/WAI/GL/wiki/Relative_luminance
 const vec3 luminance = vec3(0.2126, 0.7152, 0.0722);
-
-#define BOUNCES ${params.bounces}
-${params.useGlass ? '#define USE_GLASS' : ''}
-${params.useShadowCatcher ? '#define USE_SHADOW_CATCHER' : ''}
 
 struct Ray {
   vec3 o;
@@ -183,7 +181,7 @@ vec4 integrator(inout Ray ray) {
 
   // for (int i = 1; i < params.bounces + 1, i += 1)
   // equivelant to
-  ${unrollLoop('i', 1, params.bounces + 1, 1, `
+  ${unrollLoop('i', 1, params.BOUNCES + 1, 1, `
     li += bounce(path, i);
   `)}
 

--- a/src/renderer/glslUtil.js
+++ b/src/renderer/glslUtil.js
@@ -8,3 +8,15 @@ export function unrollLoop(indexName, start, limit, step, code) {
 
   return unrolled;
 }
+
+export function addDefines(params) {
+  let defines = '';
+
+  for (let [name, value] of Object.entries(params)) {
+    if (value) {
+      defines += `#define ${name} ${value}\n`;
+    }
+  }
+
+  return defines;
+}

--- a/src/renderer/glslUtil.js
+++ b/src/renderer/glslUtil.js
@@ -13,6 +13,8 @@ export function addDefines(params) {
   let defines = '';
 
   for (let [name, value] of Object.entries(params)) {
+    // don't define falsy values such as false, 0, and ''.
+    // this adds support for #ifdef on falsy values
     if (value) {
       defines += `#define ${name} ${value}\n`;
     }

--- a/src/renderer/rayTracingShader.js
+++ b/src/renderer/rayTracingShader.js
@@ -147,19 +147,19 @@ export function makeRayTracingShader({
 
     const fragmentShader = createShader(gl, gl.FRAGMENT_SHADER, fragString({
       OES_texture_float_linear,
-      bvhColumnsLog: bvhDim.columnsLog,
-      indexColumnsLog: indexDim.columnsLog,
-      vertexColumnsLog: vertexDim.columnsLog,
-      maxBvhDepth: flattenedBvh.maxDepth,
-      numTris: numTris,
-      numMaterials: materials.length,
-      numDiffuseMaps: maps.map.textures.length,
-      numNormalMaps: maps.normalMap.textures.length,
-      numPbrMaps: pbrMap.textures.length,
-      bounces,
-      useGlass,
-      useShadowCatcher,
-      strataDimensions: strataDimensions.reduce((a, b) => a + b)
+      BVH_COLUMNS: bvhDim.columnsLog,
+      INDEX_COLUMNS: indexDim.columnsLog,
+      VERTEX_COLUMNS: vertexDim.columnsLog,
+      STACK_SIZE: flattenedBvh.maxDepth,
+      NUM_TRIS: numTris,
+      NUM_MATERIALS: materials.length,
+      NUM_DIFFUSE_MAPS: maps.map.textures.length,
+      NUM_NORMAL_MAPS: maps.normalMap.textures.length,
+      NUM_PBR_MAPS: pbrMap.textures.length,
+      BOUNCES: bounces,
+      USE_GLASS: useGlass,
+      USE_SHADOW_CATCHER: useShadowCatcher,
+      STRATA_DIMENSIONS: strataDimensions.reduce((a, b) => a + b)
     }));
 
     const program = createProgram(gl, fullscreenQuad.vertexShader, fragmentShader);


### PR DESCRIPTION
## Brief Description
This PR adds a helper function which automatically places `#define` directives in the GLSL code. This gets rid of some messy copy-pasted code that made adding newly defined constants difficult.

## Pull Request Guidelines
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] I have added pull requests labels which describe my contribution.
- [x] All existing tests passed.
    - [ ] I have added tests to cover my changes, of which pass.
- [x] I have [compared](https://github.com/hoverinc/ray-tracing-renderer/wiki/Contributing#comparing-changes) the render output of my branch to `master`.
- [x] My code has passed the ESLint configuration for this project.
- [ ] My change requires modifications to the documentation.
    - [ ] I have updated the documentation accordingly.
