### PR TITLE
Fix npm package name in example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ const renderer = new THREE.RayTracingRenderer();
 #### As a module
 If you installed via npm, simply import the renderer as follows.
 ```javascript
-import { RayTracingRenderer } from 'three.js-ray-tracing-renderer'
+import { RayTracingRenderer } from 'ray-tracing-renderer'
 ```
 Or if you downloaded the renderer as a file,
 ```javascript


### PR DESCRIPTION
The README was using an old package name. Update the name to the actual package name.