### PR TITLE
Fix module importing

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -5,8 +5,8 @@ import { EnvironmentLight } from './EnvironmentLight';
 import { RayTracingMaterial } from './RayTracingMaterial';
 import { RayTracingRenderer } from './RayTracingRenderer';
 
-/* global THREE */
-if (THREE) {
+if (window.THREE) {
+  /* global THREE */
   THREE.LensCamera = LensCamera;
   THREE.SoftDirectionalLight = SoftDirectionalLight;
   THREE.EnvironmentLight = EnvironmentLight;

--- a/src/renderer/RayTracingShader.js
+++ b/src/renderer/RayTracingShader.js
@@ -1,5 +1,6 @@
 import * as THREE from 'three';
 import fragString from './glsl/rayTrace.frag';
+import { EnvironmentLight } from '../EnvironmentLight';
 import { createShader, createProgram, getUniforms } from './glUtil';
 import { mergeMeshesToGeometry } from './mergeMeshesToGeometry';
 import { bvhAccel, flattenBvh } from './bvhAccel';
@@ -266,7 +267,7 @@ function decomposeScene(scene) {
     if (child instanceof THREE.DirectionalLight) {
       directionalLights.push(child);
     }
-    if (child instanceof THREE.EnvironmentLight) {
+    if (child instanceof EnvironmentLight) {
       if (environmentLights.length > 1) {
         console.warn(environmentLights, 'only one environment light can be used per scene');
       }


### PR DESCRIPTION
## Brief Description
Fixes the issue described in https://github.com/hoverinc/ray-tracing-renderer/issues/20. I've tested that the renderer now correctly loads via

* HTML-loaded Three.js and HTML-loaded Ray Tracing Renderer
* HTML-loaded Three.js and module-loaded Ray Tracing Renderer
* Module-loaded Three.js and module-loaded Ray Tracing Renderer

## Pull Request Guidelines
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] I have added pull requests labels which describe my contribution.
- [x] All existing tests passed.
    - [ ] I have added tests to cover my changes, of which pass.
- [x] I have [compared](https://github.com/hoverinc/ray-tracing-renderer/wiki/Contributing#comparing-changes) the render output of my branch to `master`.
- [x] My code has passed the ESLint configuration for this project.
- [ ] My change requires modifications to the documentation.
    - [ ] I have updated the documentation accordingly.
