### PR TITLE
chore(instanceof): remove instanceof usage

### DIFF
--- a/src/EnvironmentLight.js
+++ b/src/EnvironmentLight.js
@@ -4,6 +4,7 @@ export class EnvironmentLight extends Light {
   constructor(map, ...args) {
     super(...args);
     this.map = map;
+    this.isEnvironmentLight = true;
   }
 
   copy(source) {

--- a/src/renderer/RayTracingShader.js
+++ b/src/renderer/RayTracingShader.js
@@ -254,20 +254,20 @@ function decomposeScene(scene) {
   const directionalLights = [];
   const environmentLights = [];
   scene.traverse(child => {
-    if (child instanceof THREE.Mesh) {
+    if (child.isMesh) {
       if (!child.geometry || !child.geometry.getAttribute('position')) {
         console.warn(child, 'must have a geometry property with a position attribute');
       }
-      else if (!(child.material instanceof THREE.MeshStandardMaterial)) {
+      else if (!(child.material.isMeshStandardMaterial)) {
         console.warn(child, 'must use MeshStandardMaterial in order to be rendered.');
       } else {
         meshes.push(child);
       }
     }
-    if (child instanceof THREE.DirectionalLight) {
+    if (child.isDirectionalLight) {
       directionalLights.push(child);
     }
-    if (child instanceof EnvironmentLight) {
+    if (child.isEnvironmentLight) {
       if (environmentLights.length > 1) {
         console.warn(environmentLights, 'only one environment light can be used per scene');
       }

--- a/test/EnvironmentLight.test.js
+++ b/test/EnvironmentLight.test.js
@@ -12,11 +12,17 @@ describe('constructor', () => {
   });
 
   test('initializes "map" with the parameter provided', () => {
-    expect(new EnvironmentLight().map).toBe(undefined);
+    expect(light.map).toBe(undefined);
     expect(new EnvironmentLight(5).map).toBe(5);
   });
 
-  test('creates en instance where "isEnvironmentLight=true"', () => {
+  test('initializes "color" and "intensity" of the base class', () => {
+    const lightWithParams = new EnvironmentLight(null, 0x555555, 0.5);
+    expect(lightWithParams.color.getHex()).toBe(0x555555);
+    expect(lightWithParams.intensity).toBe(0.5);
+  });
+
+  test('creates an instance where "isEnvironmentLight == true"', () => {
     expect(light.isEnvironmentLight).toBe(true);
   });
 });

--- a/test/EnvironmentLight.test.js
+++ b/test/EnvironmentLight.test.js
@@ -1,0 +1,22 @@
+import { EnvironmentLight } from 'src/EnvironmentLight';
+import * as THREE from 'three';
+
+describe('constructor', () => {
+  let light;
+  beforeEach(() => {
+    light = new EnvironmentLight();
+  });
+
+  test('extends from the "Light" object', () => {
+    expect(light instanceof THREE.Light).toBe(true);
+  });
+
+  test('initializes "map" with the parameter provided', () => {
+    expect(new EnvironmentLight().map).toBe(undefined);
+    expect(new EnvironmentLight(5).map).toBe(5);
+  });
+
+  test('creates en instance where "isEnvironmentLight=true"', () => {
+    expect(light.isEnvironmentLight).toBe(true);
+  });
+});


### PR DESCRIPTION
## Brief Description
replace `instanceof` usage with `isNameOfClass`. This provides more
flexibility in using different `three.js` versions between this library
and an application. Also, older three.js versions rely too much on a global
`window` object. Older code may have problems integrating the library.

## Pull Request Guidelines
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] I have added pull requests labels which describe my contribution.
- [x] All existing tests passed.
    - [x] I have added tests to cover my changes, of which pass.
- [x] I have [compared](https://github.com/hoverinc/ray-tracing-renderer/wiki/Contributing#comparing-changes) the render output of my branch to `master`.
- [x] My code has passed the ESLint configuration for this project.
- [ ] My change requires modifications to the documentation.
    - [ ] I have updated the documentation accordingly.
