### PR TITLE
Use ES6 build for the main library entry point

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ray-tracing-renderer",
   "version": "0.2.0",
   "description": "A [Three.js](https://github.com/mrdoob/three.js/) renderer which utilizes path tracing to render a scene with true photorealism. The renderer supports global illumination, reflections, soft shadows, and realistic environment lighting.",
-  "main": "src/main.js",
+  "main": "build/RayTracingRenderer.js",
   "scripts": {
     "build": "./node_modules/.bin/rollup -c",
     "dev": "./node_modules/.bin/rollup -cw --environment DEV & ./node_modules/.bin/http-server",


### PR DESCRIPTION
## Brief Description
Firstly, thanks for the amazing project.

The current library entry point is `src/main.js`, meaning if you `npm install ray-tracing-renderer` then you'll import the untranspiled modules into your app. This almost works, but most bundlers won't recognize .vert or .frag files out of the box, in the case of wepback this results in a runtime error when trying to use the library.

Either it could be documented that glsl files need to be recognized by the consumers' bundler, or the entry could be pointed at the ES6 build as in this PR.

## Pull Request Guidelines
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] I have added pull requests labels which describe my contribution.
- [ ] All existing tests passed.
    - [ ] I have added tests to cover my changes, of which pass.
- [ ] I have [compared](https://github.com/hoverinc/ray-tracing-renderer/wiki/Contributing#comparing-changes) the render output of my branch to `master`.
- [ ] My code has passed the ESLint configuration for this project.
- [ ] My change requires modifications to the documentation.
    - [ ] I have updated the documentation accordingly.
