### PR TITLE
sample-scene: Update aperture according to scene size

### DIFF
--- a/scenes/sample-models/main.js
+++ b/scenes/sample-models/main.js
@@ -125,6 +125,8 @@ function updateCameraFromModel(camera, model) {
   // TODO: Why do we need this?
   // controls.target.set(centroid);
   camera.position.set(0, (bounds.max.y - bounds.min.y) * 0.75, distance * 2.0);
+  camera.aperture = 0.01 * distance;
+
   controls.target.copy(centroid);
   controls.update();
 


### PR DESCRIPTION
## Brief Description
Aperture controls the distance from the focal point that the camera will be in focus. So that the amount of blurring appears the same between models, regardless of model size, we can set the aperture based on the bounding box, similar to how we handle the camera position.

I've set the aperture to a high enough level so that the blur is somewhat visible. I like the effect because it looks realistic and shows off the features of our custom camera, but maybe the blur is too distracting?

## Image(s) or GIFs (if applicable)
![Screenshot from 2019-11-05 20-36-01](https://user-images.githubusercontent.com/4411068/68268675-0fa06980-000c-11ea-84dd-5959c504e6bd.png)


## Pull Request Guidelines
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] I have added pull requests labels which describe my contribution.
- [x] All existing tests passed.
    - [ ] I have added tests to cover my changes, of which pass.
- [x] I have [compared](https://github.com/hoverinc/ray-tracing-renderer/wiki/Contributing#comparing-changes) the render output of my branch to `master`.
- [x] My code has passed the ESLint configuration for this project.
- [ ] My change requires modifications to the documentation.
    - [ ] I have updated the documentation accordingly.
