### PR TITLE
chore(sample-models): create remote example

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 # Ray Tracing Renderer
 A [Three.js](https://github.com/mrdoob/three.js/) renderer which utilizes path tracing to render a scene with true photorealism. The renderer supports global illumination, reflections, soft shadows, and realistic environment lighting.
 
-[User Guide](https://github.com/hoverinc/ray-tracing-renderer/wiki/User-Guide) | [API Reference](https://github.com/hoverinc/ray-tracing-renderer/wiki/RayTracingRenderer) | [Contributing](https://github.com/hoverinc/ray-tracing-renderer/wiki/Contributing)
+[Demo](https://hoverinc.github.io/ray-tracing-renderer/scenes/sample-models/) [User Guide](https://github.com/hoverinc/ray-tracing-renderer/wiki/User-Guide) | [API Reference](https://github.com/hoverinc/ray-tracing-renderer/wiki/RayTracingRenderer) | [Contributing](https://github.com/hoverinc/ray-tracing-renderer/wiki/Contributing)
 
 
 ## Usage

--- a/scenes/sample-models/dev.html
+++ b/scenes/sample-models/dev.html
@@ -27,6 +27,6 @@
 </head>
 
 <body>
-  <script src="main.js"></script>
+  <script src="/scenes/sample-models/main.js"></script>
 </body>
 </html>

--- a/scenes/sample-models/dev.html
+++ b/scenes/sample-models/dev.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Path Tracing - Sample Models</title>
+
+  <script src="/node_modules/three/build/three.js"></script>
+  <script src="/node_modules/three/examples/js/loaders/GLTFLoader.js"></script>
+  <script src="/node_modules/three/examples/js/controls/OrbitControls.js"></script>
+  <script src="/node_modules/three/examples/js/loaders/RGBELoader.js"></script>
+  <script src="/node_modules/stats.js/build/stats.min.js"></script>
+  <script src="/node_modules/dat.gui/build/dat.gui.min.js"></script>
+  <script src="/build/RayTracingRenderer.js"></script>
+
+  <style>
+    html, body {
+      margin: 0;
+      padding: 0;
+      width: 100%;
+      height: 100%;
+    }
+
+    canvas {
+      display: block;
+    }
+  </style>
+</head>
+
+<body>
+  <script src="main.js"></script>
+</body>
+</html>

--- a/scenes/sample-models/index.html
+++ b/scenes/sample-models/index.html
@@ -10,7 +10,7 @@
   <script src="https://cdn.jsdelivr.net/npm/three@0.108.0/examples/js/loaders/RGBELoader.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/three@0.108.0/examples/js/libs/stats.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/three@0.108.0/examples/js/libs/dat.gui.min.js"></script>
-  <script src="https://hoverinc.github.io/ray-tracing-renderer/build/RayTracingRenderer.js"></script>
+  <script src="/build/RayTracingRenderer.js"></script>
 
   <style>
     html, body {
@@ -27,6 +27,6 @@
 </head>
 
 <body>
-  <script src="https://hoverinc.github.io/ray-tracing-renderer/scenes/sample-models/main.js"></script>
+  <script src="/scenes/sample-models/main.js"></script>
 </body>
 </html>

--- a/scenes/sample-models/index.html
+++ b/scenes/sample-models/index.html
@@ -3,13 +3,15 @@
 <head>
   <meta charset="utf-8">
   <title>Path Tracing - Sample Models</title>
-  <script src="/node_modules/three/build/three.js"></script>
-  <script src="/node_modules/three/examples/js/loaders/GLTFLoader.js"></script>
-  <script src="/node_modules/three/examples/js/controls/OrbitControls.js"></script>
-  <script src="/node_modules/three/examples/js/loaders/RGBELoader.js"></script>
-  <script src="/node_modules/stats.js/build/stats.min.js"></script>
-  <script src="/node_modules/dat.gui/build/dat.gui.min.js"></script>
-  <script src="/build/RayTracingRenderer.js"></script>
+
+  <script src="https://cdn.jsdelivr.net/npm/three@0.108.0/build/three.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/three@0.108.0/examples/js/loaders/GLTFLoader.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/three@0.108.0/examples/js/controls/OrbitControls.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/three@0.108.0/examples/js/loaders/RGBELoader.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/three@0.108.0/examples/js/libs/stats.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/three@0.108.0/examples/js/libs/dat.gui.min.js"></script>
+  <script src="https://hoverinc.github.io/ray-tracing-renderer/build/RayTracingRenderer.js"></script>
+
   <style>
     html, body {
       margin: 0;
@@ -25,6 +27,6 @@
 </head>
 
 <body>
-  <script src="main.js"></script>
+  <script src="https://hoverinc.github.io/ray-tracing-renderer/scenes/sample-models/main.js"></script>
 </body>
 </html>

--- a/scenes/sample-models/main.js
+++ b/scenes/sample-models/main.js
@@ -1,5 +1,13 @@
 // TODO: Support multiple hdr maps
-const DEFAULT_ENV_MAP_PATH = '/scenes/envmaps/gray-background-with-dirlight.hdr';
+
+// Dev HOST
+// const HOST = 'https://localhost:8080';
+
+// Remote HOST
+const HOST = 'https://hoverinc.github.io/ray-tracing-renderer';
+
+// Envinronment maps
+const DEFAULT_ENV_MAP_PATH = 'scenes/envmaps/gray-background-with-dirlight.hdr';
 
 // Sample models from BabylonJS: http://models.babylonjs.com/
 const BABYLON_JS_SAMPLE_MODELS = [
@@ -167,7 +175,7 @@ async function init() {
   window.addEventListener('resize', resize);
   resize();
 
-  const envMap = new THREE.RGBELoader().load(DEFAULT_ENV_MAP_PATH);
+  const envMap = new THREE.RGBELoader().load(`${HOST}/${DEFAULT_ENV_MAP_PATH}`);
   const envLight = new THREE.EnvironmentLight(envMap);
 
   groundMesh = createGroundMesh();

--- a/scenes/sample-models/main.js
+++ b/scenes/sample-models/main.js
@@ -1,13 +1,7 @@
 // TODO: Support multiple hdr maps
 
-// Dev HOST
-// const HOST = 'https://localhost:8080';
-
-// Remote HOST
-const HOST = 'https://hoverinc.github.io/ray-tracing-renderer';
-
 // Envinronment maps
-const DEFAULT_ENV_MAP_PATH = 'scenes/envmaps/gray-background-with-dirlight.hdr';
+const DEFAULT_ENV_MAP_PATH = '/scenes/envmaps/gray-background-with-dirlight.hdr';
 
 // Sample models from BabylonJS: http://models.babylonjs.com/
 const BABYLON_JS_SAMPLE_MODELS = [
@@ -175,7 +169,7 @@ async function init() {
   window.addEventListener('resize', resize);
   resize();
 
-  const envMap = new THREE.RGBELoader().load(`${HOST}/${DEFAULT_ENV_MAP_PATH}`);
+  const envMap = new THREE.RGBELoader().load(`${DEFAULT_ENV_MAP_PATH}`);
   const envLight = new THREE.EnvironmentLight(envMap);
 
   groundMesh = createGroundMesh();


### PR DESCRIPTION
## Brief Description
This change updates `sample-models/index.html` to fetch resources from remote CDNs instead of using local file paths. This way, we can take advantage of using the example directly from the following URL: https://hoverinc.github.io/ray-tracing-renderer/scenes/sample-models/

There is an HTML clone, named `dev.html` for local development. Ideally, we would have a script that injects the paths accordingly. We can tackle that change in the future.

## Pull Request Guidelines
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] I have added pull requests labels which describe my contribution.
- [x] All existing tests passed.
    - [ ] I have added tests to cover my changes, of which pass.
- [ ] I have [compared](https://github.com/hoverinc/ray-tracing-renderer/wiki/Contributing#comparing-changes) the render output of my branch to `master`.
- [x] My code has passed the ESLint configuration for this project.
- [x] My change requires modifications to the documentation.
    - [x] I have updated the documentation accordingly.
