### PR TITLE
fix(sample-models): Offset ground plane

### DIFF
--- a/scenes/sample-models/main.js
+++ b/scenes/sample-models/main.js
@@ -111,7 +111,6 @@ function createGroundMesh() {
   mat.metalness = 0.0;
   mat.shadowCatcher = true;
   const mesh = new THREE.Mesh(geo, mat);
-  mesh.position.set(0, 0, -5);
   mesh.rotateX(Math.PI / 2);
 
   return mesh;
@@ -152,7 +151,7 @@ function updateGroundMeshFromModel(groundMesh, model) {
   const bounds = computeBoundingBoxFromModel(model);
 
   const x = currentModelLoaded.position.x;
-  const y = bounds.min.y;
+  const y = bounds.min.y - 0.005 * (bounds.max.y - bounds.min.y); // move slightly below bounds to prevent z-fighting
   const z = currentModelLoaded.position.z;
 
   groundMesh.position.set(x, y, z);


### PR DESCRIPTION
## Brief Description
This PR moves the ground plane slightly below the bounding box of the model. This ensures that any floor belonging to the model doesn't perfectly rest inside the ground plane, which leads to z-fighting. 

## Pull Request Guidelines
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] I have added pull requests labels which describe my contribution.
- [x] All existing tests passed.
    - [ ] I have added tests to cover my changes, of which pass.
- [x] I have [compared](https://github.com/hoverinc/ray-tracing-renderer/wiki/Contributing#comparing-changes) the render output of my branch to `master`.
- [x] My code has passed the ESLint configuration for this project.
- [ ] My change requires modifications to the documentation.
    - [ ] I have updated the documentation accordingly.
