### PR TITLE
Scenes with a background property will by default display that as the…

### DIFF
--- a/src/renderer/RayTracingShader.js
+++ b/src/renderer/RayTracingShader.js
@@ -225,24 +225,30 @@ function makeProgramFromScene({
   );
 
   const envImage = generateEnvMapFromSceneComponents(directionalLights, environmentLights);
-
-  textureAllocator.bind(uniforms.envmap, makeTexture(gl, {
+  const envImageTextureObject = makeTexture(gl, {
     data: envImage.data,
     minFilter: OES_texture_float_linear ? gl.LINEAR : gl.NEAREST,
     magFilter: OES_texture_float_linear ? gl.LINEAR : gl.NEAREST,
     width: envImage.width,
     height: envImage.height,
-  }));
+  });
 
-  const backgroundImage = (scene.background) ? generateBackgroundMapFromSceneBackground(scene.background) : envImage;
+  textureAllocator.bind(uniforms.envmap, envImageTextureObject);
 
-  textureAllocator.bind(uniforms.backgroundMap, makeTexture(gl, {
-    data: backgroundImage.data,
-    minFilter: OES_texture_float_linear ? gl.LINEAR : gl.NEAREST,
-    magFilter: OES_texture_float_linear ? gl.LINEAR : gl.NEAREST,
-    width: backgroundImage.width,
-    height: backgroundImage.height,
-  }));
+  let backgroundImageTextureObject;
+  if (scene.background) {
+    const backgroundImage = generateBackgroundMapFromSceneBackground(scene.background);
+    backgroundImageTextureObject = makeTexture(gl, {
+      data: backgroundImage.data,
+      minFilter: OES_texture_float_linear ? gl.LINEAR : gl.NEAREST,
+      magFilter: OES_texture_float_linear ? gl.LINEAR : gl.NEAREST,
+      width: backgroundImage.width,
+      height: backgroundImage.height,
+    });
+  } else {
+    backgroundImageTextureObject = envImageTextureObject;
+  }
+  textureAllocator.bind(uniforms.backgroundMap, backgroundImageTextureObject);
 
   const distribution = envmapDistribution(envImage);
   textureAllocator.bind(uniforms.envmapDistribution, makeTexture(gl, {

--- a/src/renderer/envMapCreation.js
+++ b/src/renderer/envMapCreation.js
@@ -16,7 +16,7 @@ export function generateBackgroundMapFromSceneBackground(background) {
   let backgroundImage;
 
   if (background.isColor) {
-    backgroundImage = generateSolidMap(DEFAULT_MAP_RESOLUTION.width, DEFAULT_MAP_RESOLUTION.height, background);
+    backgroundImage = generateSolidMap(1, 1, background);
   } else if (background.encoding === THREE.RGBEEncoding) {
       backgroundImage = {
         width: background.image.width,
@@ -30,7 +30,7 @@ export function generateBackgroundMapFromSceneBackground(background) {
 
 export function generateEnvMapFromSceneComponents(directionalLights, ambientLights, environmentLights) {
   let envImage = initializeEnvMap(environmentLights);
-  ambientLights.forEach( light => { addAmbientLightToEnvMap(light, envImage) });
+  ambientLights.forEach( light => { addAmbientLightToEnvMap(light, envImage); });
   directionalLights.forEach( light => { envImage.data = addDirectionalLightToEnvMap(light, envImage); });
 
   return envImage;
@@ -99,7 +99,7 @@ export function addAmbientLightToEnvMap(light, image) {
     else if (component === 2) {
       image.data[index] += color.b * light.intensity;
     }
-  })
+  });
 }
 
 export function addDirectionalLightToEnvMap(light, image) {

--- a/src/renderer/envMapCreation.js
+++ b/src/renderer/envMapCreation.js
@@ -75,7 +75,7 @@ export function generateBackgroundMapFromSceneBackground(background) {
   return backgroundImage;
 }
 
-function setBufferToColor(buffer, color, intensity) {
+function setBufferToColor(buffer, color, intensity = 1) {
   buffer.forEach(function(part, index) {
     const component = index % 3;
     if (component === 0) {

--- a/src/renderer/glsl/chunks/envmap.glsl
+++ b/src/renderer/glsl/chunks/envmap.glsl
@@ -6,6 +6,7 @@ export default function(defines) {
 
 uniform sampler2D envmap;
 uniform sampler2D envmapDistribution;
+uniform sampler2D backgroundMap;
 
 vec2 cartesianToEquirect(vec3 pointOnSphere) {
   float phi = mod(atan(-pointOnSphere.z, -pointOnSphere.x), TWOPI);
@@ -103,6 +104,11 @@ float envmapPdf(vec2 uv) {
 vec3 sampleEnvmapFromDirection(vec3 d) {
   vec2 uv = cartesianToEquirect(d);
   return textureLinear(envmap, uv).rgb;
+}
+
+vec3 sampleBackgroundFromDirection(vec3 d) {
+  vec2 uv = cartesianToEquirect(d);
+  return textureLinear(backgroundMap, uv).rgb;
 }
 
 `;

--- a/src/renderer/glsl/chunks/sampleGlassSpecular.glsl
+++ b/src/renderer/glsl/chunks/sampleGlassSpecular.glsl
@@ -30,7 +30,7 @@ vec3 sampleGlassSpecular(SurfaceInteraction si, int bounce, inout Ray ray, inout
   const int usedSamples = 1;
   sampleIndex += SAMPLES_PER_MATERIAL - usedSamples;
 
-  return bounce == BOUNCES ? beta * sampleEnvmapFromDirection(lightDir) : vec3(0.0);
+  return bounce == BOUNCES ? beta * sampleBackgroundFromDirection(lightDir) : vec3(0.0);
 }
 
 #endif

--- a/src/renderer/glsl/chunks/sampleShadowCatcher.glsl
+++ b/src/renderer/glsl/chunks/sampleShadowCatcher.glsl
@@ -79,10 +79,10 @@ float importanceSampleMaterialShadowCatcher(SurfaceInteraction si, vec3 viewDir,
   return li;
 }
 
-vec3 sampleShadowCatcher(SurfaceInteraction si, int bounce, inout Ray ray, inout vec3 beta, inout float alpha, inout vec3 prevLi, inout bool abort) {
+vec3 sampleShadowCatcher(SurfaceInteraction si, int bounce, bool specular, inout Ray ray, inout vec3 beta, inout float alpha, inout vec3 prevLi, inout bool abort) {
   mat3 basis = orthonormalBasis(si.normal);
   vec3 viewDir = -ray.d;
-  vec3 color = mix(sampleBackgroundFromDirection(-viewDir), sampleEnvmapFromDirection(-viewDir), vec3(float(bounce > 1)));
+  vec3 color = bounce > 1 && !specular ? sampleEnvmapFromDirection(-viewDir) : sampleBackgroundFromDirection(-viewDir);
 
   vec3 lightDir = lightDirDiffuse(si.faceNormal, viewDir, basis, randomSampleVec2());
 

--- a/src/renderer/glsl/chunks/sampleShadowCatcher.glsl
+++ b/src/renderer/glsl/chunks/sampleShadowCatcher.glsl
@@ -82,7 +82,7 @@ float importanceSampleMaterialShadowCatcher(SurfaceInteraction si, vec3 viewDir,
 vec3 sampleShadowCatcher(SurfaceInteraction si, int bounce, inout Ray ray, inout vec3 beta, inout float alpha, inout vec3 prevLi, inout bool abort) {
   mat3 basis = orthonormalBasis(si.normal);
   vec3 viewDir = -ray.d;
-  vec3 color = sampleEnvmapFromDirection(-viewDir);
+  vec3 color = mix(sampleBackgroundFromDirection(-viewDir), sampleEnvmapFromDirection(-viewDir), vec3(float(bounce > 1)));
 
   vec3 lightDir = lightDirDiffuse(si.faceNormal, viewDir, basis, randomSampleVec2());
 

--- a/src/renderer/glsl/rayTrace.frag
+++ b/src/renderer/glsl/rayTrace.frag
@@ -141,7 +141,7 @@ void bounce(inout Path path, int i) {
     #endif
     #ifdef USE_SHADOW_CATCHER
       if (si.materialType == SHADOW_CATCHER) {
-        path.li += sampleShadowCatcher(si, i, path.ray, path.beta, path.alpha, path.li, path.abort);
+        path.li += sampleShadowCatcher(si, i, path.specularBounce, path.ray, path.beta, path.alpha, path.li, path.abort);
         path.specularBounce = false;
       }
     #endif

--- a/src/renderer/glsl/rayTrace.frag
+++ b/src/renderer/glsl/rayTrace.frag
@@ -128,7 +128,7 @@ void bounce(inout Path path, int i) {
 
   if (!si.hit) {
     if (path.specularBounce) {
-      path.li += path.beta * sampleEnvmapFromDirection(path.ray.d);
+      path.li += path.beta * sampleBackgroundFromDirection(path.ray.d);
     }
 
     path.abort = true;


### PR DESCRIPTION
## Brief Description
de-couple scene lighting map from scene background

Scenes with a background property will by default display that as the background instead of any environment lights that might be present.
If no background property is specified scene will fall back to using an environment light for the background

An environment light with no map will now respect it's `color` property

## Pull Request Guidelines
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] I have added pull requests labels which describe my contribution.
- [x] All existing tests passed.
    - [ ] I have added tests to cover my changes, of which pass.
- [ ] I have [compared](https://github.com/hoverinc/ray-tracing-renderer/wiki/Contributing#comparing-changes) the render output of my branch to `master`.
- [x] My code has passed the ESLint configuration for this project.
- [x] My change requires modifications to the documentation.
    - [ ] I have updated the documentation accordingly.
