### PR TITLE
fix(sample-models): Stop previous animation frame on model change

### DIFF
--- a/scenes/sample-models/main.js
+++ b/scenes/sample-models/main.js
@@ -87,13 +87,15 @@ function resize() {
   }
 }
 
+let animationFrameId;
+
 const tick = () => {
   controls.update();
   camera.focus = controls.target.distanceTo(camera.position);
   stats.begin();
   renderer.render(scene, camera);
   stats.end();
-  requestAnimationFrame(tick);
+  animationFrameId = requestAnimationFrame(tick);
 };
 
 function load(loader, url) {
@@ -231,11 +233,13 @@ async function init() {
     .name('env map');
 
   modelController.onChange(async (value) => {
-    selectModelFromName(value)
+    cancelAnimationFrame(animationFrameId);
+    selectModelFromName(value);
   });
 
   envMapController.onChange(async (value) => {
-    selectEnvMapFromName(value)
+    cancelAnimationFrame(animationFrameId);
+    selectEnvMapFromName(value);
   });
 
   THREE.DefaultLoadingManager.onLoad = tick;


### PR DESCRIPTION
## Brief Description
When the model or envmap is changed from the UI, a new model is loaded, and a new `tick` animation frame is started with
```javascript
THREE.DefaultLoadingManager.onLoad = tick;
```
However, the old animation frame is never stopped, so changing the model starts *two* animation frames, which means `renderer.render()` is called twice per frame. This PR fixes the issue by canceling the old animation frame when changing models.

## Pull Request Guidelines
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] I have added pull requests labels which describe my contribution.
- [x] All existing tests passed.
    - [ ] I have added tests to cover my changes, of which pass.
- [x] I have [compared](https://github.com/hoverinc/ray-tracing-renderer/wiki/Contributing#comparing-changes) the render output of my branch to `master`.
- [x] My code has passed the ESLint configuration for this project.
- [ ] My change requires modifications to the documentation.
    - [ ] I have updated the documentation accordingly.
