### PR TITLE
Sample-models: Simplify URLs

### DIFF
--- a/scenes/sample-models/main.js
+++ b/scenes/sample-models/main.js
@@ -1,21 +1,13 @@
-const ORIGIN = window.location.origin;
-const REMOTE_ORIGIN = 'https://hoverinc.github.io/ray-tracing-renderer/';
-const PREFIX = ORIGIN.includes('localhost') ? ORIGIN : REMOTE_ORIGIN;
-
 // Envinronment maps
 const ENV_MAPS_SAMPLES = [
   {
-    path: `${PREFIX}/scenes/envmaps/gray-background-with-dirlight.hdr`,
+    path: '../envmaps/gray-background-with-dirlight.hdr',
     name: 'Gray + Dir Light',
   },
   {
-    path: `${PREFIX}/scenes/envmaps/blurry-sunset-with-dirlight.hdr`,
+    path: '../envmaps/blurry-sunset-with-dirlight.hdr',
     name: 'Sunset + Dir Light',
-  },
-  {
-    path: `${PREFIX}/scenes/envmaps/street-by-water.hdr`,
-    name: 'Street by Water',
-  },
+  }
 ];
 
 // Sample models from BabylonJS: http://models.babylonjs.com/


### PR DESCRIPTION
## Brief Description
This PR gets rid of the URL logic which decides where to load envmaps by replacing the urls with relative paths that work on both dev and github pages (tested in this PR https://github.com/hoverinc/ray-tracing-renderer/pull/52). The code is slightly simpler.

## Pull Request Guidelines
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] I have added pull requests labels which describe my contribution.
- [x] All existing tests passed.
    - [ ] I have added tests to cover my changes, of which pass.
- [x] I have [compared](https://github.com/hoverinc/ray-tracing-renderer/wiki/Contributing#comparing-changes) the render output of my branch to `master`.
- [x] My code has passed the ESLint configuration for this project.
- [ ] My change requires modifications to the documentation.
    - [ ] I have updated the documentation accordingly.
