### PR TITLE
Fix corrupt pixels caused by zero division

### DIFF
--- a/src/renderer/RenderingPipeline.js
+++ b/src/renderer/RenderingPipeline.js
@@ -4,10 +4,8 @@ import { makeToneMapShader } from './ToneMapShader';
 import { makeFramebuffer } from './Framebuffer';
 import { numberArraysEqual, clamp } from './util';
 import { makeTileRender } from './TileRender';
-import { LensCamera } from '../LensCamera';
 import { makeTextureAllocator } from './TextureAllocator';
 import { makeReprojectShader } from './ReprojectShader';
-import * as THREE from 'three';
 import noiseBase64 from './texture/noise';
 import { PerspectiveCamera } from 'three';
 
@@ -81,6 +79,10 @@ export function makeRenderingPipeline({
   const tileRender = makeTileRender(gl);
 
   const lastCamera = new PerspectiveCamera();
+
+  // an initial camera position of 0 causes division by zero in the reprojection shader
+  lastCamera.position.set(1, 1, 1);
+  lastCamera.updateMatrixWorld();
 
   // how many samples to render with uniform noise before switching to stratified noise
   const numUniformSamples = 6;


### PR DESCRIPTION
## Brief Description
Fix a bug which caused corrupt pixels to spread across the screen during reprojection. We might want to handle zero values directly in the shader itself, but I'm worried checking for zero on every pixel might carry a performance hit on some devices. This fix completely addresses the problem outside the shader, and I haven't been able to reproduce any more NaN pixels after this change.

## Pull Request Guidelines
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] I have added pull requests labels which describe my contribution.
- [x] All existing tests passed.
    - [ ] I have added tests to cover my changes, of which pass.
- [x] I have [compared](https://github.com/hoverinc/ray-tracing-renderer/wiki/Contributing#comparing-changes) the render output of my branch to `master`.
- [x] My code has passed the ESLint configuration for this project.
- [ ] My change requires modifications to the documentation.
    - [ ] I have updated the documentation accordingly.
