### PR TITLE
Tweak reprojection amount & decrease bounces to 2

### DIFF
--- a/scenes/webgl-comparison/main.js
+++ b/scenes/webgl-comparison/main.js
@@ -154,6 +154,7 @@ function initRenderer(renderer) {
   renderer.toneMapping = THREE.ACESFilmicToneMapping;
   renderer.toneMappingExposure = 1.5;
   renderer.renderWhenOffFocus = false;
+  renderer.bounces = 3;
 }
 
 function unloadRenderer(renderer) {

--- a/src/RayTracingRenderer.js
+++ b/src/RayTracingRenderer.js
@@ -31,7 +31,7 @@ export function RayTracingRenderer(params = {}) {
   let pixelRatio = 1;
 
   const module = {
-    bounces: 3,
+    bounces: 2,
     domElement: canvas,
     maxHardwareUsage: false,
     needsUpdate: true,

--- a/src/renderer/RenderingPipeline.js
+++ b/src/renderer/RenderingPipeline.js
@@ -21,7 +21,7 @@ export function makeRenderingPipeline({
   const maxReprojectedSamples = 20;
 
   // how many samples to render with uniform noise before switching to stratified noise
-  const numUniformSamples = 3;
+  const numUniformSamples = 4;
 
   // how many partitions of stratified noise should be created
   // higher number results in faster convergence over time, but with lower quality initial samples

--- a/src/renderer/RenderingPipeline.js
+++ b/src/renderer/RenderingPipeline.js
@@ -18,8 +18,7 @@ export function makeRenderingPipeline({
     bounces, // number of global illumination bounces
   }) {
 
-  const reprojectDecay = 0.975;
-  const maxReprojectedSamples = Math.round(reprojectDecay / (1 - reprojectDecay));
+  const maxReprojectedSamples = 25;
 
   // how many samples to render with uniform noise before switching to stratified noise
   const numUniformSamples = 6;
@@ -231,7 +230,7 @@ export function makeRenderingPipeline({
     reprojectBuffer.bind();
     gl.viewport(0, 0, previewWidth, previewHeight);
     reprojectPass.draw({
-      blendAmount: reprojectDecay,
+      blendAmount: 1.0,
       light: hdrBuffer.attachments[rayTracePass.outputLocs.light],
       position: hdrBuffer.attachments[rayTracePass.outputLocs.position],
       textureScale: previewScale,

--- a/src/renderer/RenderingPipeline.js
+++ b/src/renderer/RenderingPipeline.js
@@ -18,10 +18,10 @@ export function makeRenderingPipeline({
     bounces, // number of global illumination bounces
   }) {
 
-  const maxReprojectedSamples = 25;
+  const maxReprojectedSamples = 20;
 
   // how many samples to render with uniform noise before switching to stratified noise
-  const numUniformSamples = 6;
+  const numUniformSamples = 3;
 
   // how many partitions of stratified noise should be created
   // higher number results in faster convergence over time, but with lower quality initial samples


### PR DESCRIPTION
## Brief Description
This PR decreases the amount of reprojection each frame, decreasing the amount of ghosting and low resolution pixelation, at the cost of extra noise. However, the slight increase in noise looks better than the amount of ghosting present beforehand.

In addition, the default `bounces` is now set to 2. This value drastically improves performance, and is sufficient for the majority of scenes, without noticeable loss of realism. Most denoising pipelines in research papers use 2 bounces, so it makes sense to use this as a default moving forward.

## Pull Request Guidelines
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] I have added pull requests labels which describe my contribution.
- [x] All existing tests passed.
    - [ ] I have added tests to cover my changes, of which pass.
- [x] I have [compared](https://github.com/hoverinc/ray-tracing-renderer/wiki/Contributing#comparing-changes) the render output of my branch to `master`.
- [x] My code has passed the ESLint configuration for this project.
- [x] My change requires modifications to the documentation.
    - [ ] I have updated the documentation accordingly.
