### PR TITLE
Fix glsl error when scene has no materials with maps

### DIFF
--- a/src/renderer/glsl/chunks/intersect.glsl
+++ b/src/renderer/glsl/chunks/intersect.glsl
@@ -30,7 +30,7 @@ void surfaceInteractionFromBVH(inout SurfaceInteraction si, Triangle tri, vec3 b
     vec2 uv2 = texelFetch(uvs, i2, 0).xy;
     vec2 uv = fract(barycentric.x * uv0 + barycentric.y * uv1 + barycentric.z * uv2);
   #else
-    vec2 uv = vec2();
+    vec2 uv = vec2(0.0);
   #endif
 
   si.materialType = int(getMatType(materialIndex));


### PR DESCRIPTION
## Brief Description
Scenes with materials without maps give an error when loading since the hybrid refactor, I think due to constructing a vec2 without arguments.

specifically this error:
`Uncaught ERROR: 0:260: 'constructor' : constructor does not have any arguments
WARNING: 0:1206: '1.0e999' : Float overflow`

to replicate, add this code to a test scene:
```
  model.traverse(child => {
    if (child.material) {
      child.material.map = null;
      child.material.normalMap = null;
      child.material.roughnessMap = null;
      child.material.metalnessMap = null;
    }
  });
````

## Pull Request Guidelines
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] I have added pull requests labels which describe my contribution.
- [x] All existing tests passed.
    - [ ] I have added tests to cover my changes, of which pass.
- [x] I have [compared](https://github.com/hoverinc/ray-tracing-renderer/wiki/Contributing#comparing-changes) the render output of my branch to `master`.
- [x] My code has passed the ESLint configuration for this project.
- [ ] My change requires modifications to the documentation.
    - [ ] I have updated the documentation accordingly.
