### PR TITLE
Hybrid rendering bug fixes

### DIFF
--- a/src/renderer/GBufferPass.js
+++ b/src/renderer/GBufferPass.js
@@ -76,6 +76,10 @@ function uploadAttributes(gl, renderPass, geometry) {
 }
 
 function setAttribute(gl, location, bufferAttribute) {
+  if (location === undefined) {
+    return;
+  }
+
   const { itemSize, array } = bufferAttribute;
 
   gl.enableVertexAttribArray(location);

--- a/src/renderer/glsl/chunks/surfaceInteractionDirect.glsl
+++ b/src/renderer/glsl/chunks/surfaceInteractionDirect.glsl
@@ -7,7 +7,10 @@ export default `
   uniform sampler2D gMatProps;
 
   void surfaceInteractionDirect(vec2 coord, inout SurfaceInteraction si) {
+    vec4 positionAndMeshIndex = texture(gPosition, coord);
     si.position = texture(gPosition, coord).xyz;
+
+    float meshIndex = positionAndMeshIndex.w;
 
     vec4 normalMaterialType = texture(gNormal, coord);
 
@@ -22,6 +25,6 @@ export default `
     si.roughness = matProps.x;
     si.metalness = matProps.y;
 
-    si.hit = dot(si.normal, si.normal) > 0.0 ? true : false;
+    si.hit = meshIndex > 0.0 ? true : false;
   }
 `;

--- a/src/renderer/glsl/chunks/surfaceInteractionDirect.glsl
+++ b/src/renderer/glsl/chunks/surfaceInteractionDirect.glsl
@@ -8,7 +8,8 @@ export default `
 
   void surfaceInteractionDirect(vec2 coord, inout SurfaceInteraction si) {
     vec4 positionAndMeshIndex = texture(gPosition, coord);
-    si.position = texture(gPosition, coord).xyz;
+
+    si.position = positionAndMeshIndex.xyz;
 
     float meshIndex = positionAndMeshIndex.w;
 

--- a/src/renderer/glsl/gBuffer.frag
+++ b/src/renderer/glsl/gBuffer.frag
@@ -34,8 +34,8 @@ source: `
     roughness = clamp(roughness, ROUGHNESS_MIN, 1.0);
     metalness = clamp(metalness, 0.0, 1.0);
 
-    vec3 normal = vNormal;
-    vec3 faceNormal = faceNormals(vPosition);
+    vec3 normal = normalize(vNormal);
+    vec3 faceNormal = normalize(faceNormals(vPosition));
     normal *= sign(dot(normal, faceNormal));
 
     #ifdef NUM_NORMAL_MAPS

--- a/src/renderer/glsl/toneMap.frag
+++ b/src/renderer/glsl/toneMap.frag
@@ -39,8 +39,13 @@ source: `
   }
 
   #ifdef EDGE_PRESERVING_UPSCALE
+
+  float getMeshId(sampler2D meshIdTex, vec2 vCoord) {
+    return floor(texture(meshIdTex, vCoord).w);
+  }
+
   vec4 getUpscaledLight(vec2 coord) {
-    float meshId = texture(position, coord).w;
+    float meshId = getMeshId(position, coord);
 
     vec2 sizef = lightScale * vec2(textureSize(position, 0));
     vec2 texelf = coord * sizef - 0.5;
@@ -65,7 +70,7 @@ source: `
     float sum;
     for (int i = 0; i < 4; i++) {
       vec2 pCoord = (vec2(texels[i]) + 0.5) / sizef;
-      float isValid = texture(position, pCoord).w == meshId ? 1.0 : 0.0;
+      float isValid = getMeshId(position, pCoord) == meshId ? 1.0 : 0.0;
       float weight = isValid * weights[i];
       upscaledLight += weight * texelFetch(light, texels[i], 0);
       sum += weight;


### PR DESCRIPTION
## Brief Description
A handful of bug fixes for problems I found on my Windows device. None of these bugs should be present in HOVER scenes, so this isn't an emergency.

* For scenes without UVs, don't set an undefined UV attribute. While this works on some devices, this breaks g-buffer rendering on others.

* Normalize g-buffer normals in the g-buffer. We normalize these values later in the pipeline, but without doing the normalization here, the half-float precision of the render target fails to correctly record the normals.

* `dot(si.normal, si.normal)` doesn't compute correctly due to a driver bug on my Windows machine. This results in the envmap not rendering. Determine the existence of a mesh by mesh index instead.

* Not necessarily a bug, but fetch the g-buffer mesh index in the tone mapping shader the same way we fetch it from the reproject shader. This copy pasted code is not ideal and I will improve it in a future refactor.

## Pull Request Guidelines
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] I have added pull requests labels which describe my contribution.
- [x] All existing tests passed.
    - [ ] I have added tests to cover my changes, of which pass.
- [x] I have [compared](https://github.com/hoverinc/ray-tracing-renderer/wiki/Contributing#comparing-changes) the render output of my branch to `master`.
- [x] My code has passed the ESLint configuration for this project.
- [ ] My change requires modifications to the documentation.
    - [ ] I have updated the documentation accordingly.
