### PR TITLE
Fix crash on Windows 10

### DIFF
--- a/src/renderer/glsl/rayTrace.frag
+++ b/src/renderer/glsl/rayTrace.frag
@@ -90,10 +90,11 @@ source: (defines) => `
     // for (int i = 1; i < defines.bounces + 1, i += 1)
     // equivelant to
     ${unrollLoop('i', 2, defines.BOUNCES + 1, 1, `
-      if (!path.abort) {
-        intersectScene(path.ray, si);
-        bounce(path, i, si);
+      if (path.abort) {
+        return vec4(path.li, path.alpha);
       }
+      intersectScene(path.ray, si);
+      bounce(path, i, si);
     `)}
 
     return vec4(path.li, path.alpha);


### PR DESCRIPTION
## Brief Description
Refactors to the shader code in hybrid rendering introduced a driver bug only present on Windows devices. This PR tweaks the shader code so that this crash doesn't happen. The tweak fixes the crashing on my Windows machine, but we should test this on others as well.

## Pull Request Guidelines
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] I have added pull requests labels which describe my contribution.
- [x] All existing tests passed.
    - [ ] I have added tests to cover my changes, of which pass.
- [x] I have [compared](https://github.com/hoverinc/ray-tracing-renderer/wiki/Contributing#comparing-changes) the render output of my branch to `master`.
- [x] My code has passed the ESLint configuration for this project.
- [ ] My change requires modifications to the documentation.
    - [ ] I have updated the documentation accordingly.
