### PR TITLE
Rename texture variables

### DIFF
--- a/src/renderer/RayTracePass.js
+++ b/src/renderer/RayTracePass.js
@@ -1,6 +1,6 @@
 import { bvhAccel, flattenBvh } from './bvhAccel';
 import { generateEnvMapFromSceneComponents, generateBackgroundMapFromSceneBackground } from './envMapCreation';
-import { envmapDistribution } from './envmapDistribution';
+import { envMapDistribution } from './envMapDistribution';
 import fragment from './glsl/rayTrace.frag';
 import { makeRenderPass } from './RenderPass';
 import { makeStratifiedSamplerCombined } from './StratifiedSamplerCombined';
@@ -42,7 +42,7 @@ export function makeRayTracePass(gl, {
 
   // noiseImage is a 32-bit PNG image
   function setNoise(noiseImage) {
-    renderPass.setTexture('noise', makeTexture(gl, {
+    renderPass.setTexture('noiseTex', makeTexture(gl, {
       data: noiseImage,
       wrapS: gl.REPEAT,
       wrapT: gl.REPEAT,
@@ -152,13 +152,13 @@ function makeRenderPassFromScene({
   renderPass.setTexture('normalMap', materialBuffer.textures.normalMap);
   renderPass.setTexture('pbrMap', materialBuffer.textures.pbrMap);
 
-  renderPass.setTexture('positions', makeDataTexture(gl, geometry.getAttribute('position').array, 3));
+  renderPass.setTexture('positionBuffer', makeDataTexture(gl, geometry.getAttribute('position').array, 3));
 
-  renderPass.setTexture('normals', makeDataTexture(gl, geometry.getAttribute('normal').array, 3));
+  renderPass.setTexture('normalBuffer', makeDataTexture(gl, geometry.getAttribute('normal').array, 3));
 
-  renderPass.setTexture('uvs', makeDataTexture(gl, geometry.getAttribute('uv').array, 2));
+  renderPass.setTexture('uvBuffer', makeDataTexture(gl, geometry.getAttribute('uv').array, 2));
 
-  renderPass.setTexture('bvh', makeDataTexture(gl, flattenedBvh.buffer, 4));
+  renderPass.setTexture('bvhBuffer', makeDataTexture(gl, flattenedBvh.buffer, 4));
 
   const envImage = generateEnvMapFromSceneComponents(directionalLights, ambientLights, environmentLights);
   const envImageTextureObject = makeTexture(gl, {
@@ -170,7 +170,7 @@ function makeRenderPassFromScene({
     height: envImage.height,
   });
 
-  renderPass.setTexture('envmap', envImageTextureObject);
+  renderPass.setTexture('envMap', envImageTextureObject);
 
   let backgroundImageTextureObject;
   if (background) {
@@ -189,9 +189,9 @@ function makeRenderPassFromScene({
 
   renderPass.setTexture('backgroundMap', backgroundImageTextureObject);
 
-  const distribution = envmapDistribution(envImage);
+  const distribution = envMapDistribution(envImage);
 
-  renderPass.setTexture('envmapDistribution', makeTexture(gl, {
+  renderPass.setTexture('envMapDistribution', makeTexture(gl, {
     data: distribution.data,
     storage: 'halfFloat',
     width: distribution.width,

--- a/src/renderer/ReprojectPass.js
+++ b/src/renderer/ReprojectPass.js
@@ -43,10 +43,10 @@ export function makeReprojectPass(gl, params) {
     renderPass.setUniform('lightScale', lightScale.x, lightScale.y);
     renderPass.setUniform('previousLightScale', previousLightScale.x, previousLightScale.y);
 
-    renderPass.setTexture('light', light);
-    renderPass.setTexture('position', position);
-    renderPass.setTexture('previousLight', previousLight);
-    renderPass.setTexture('previousPosition', previousPosition);
+    renderPass.setTexture('lightTex', light);
+    renderPass.setTexture('positionTex', position);
+    renderPass.setTexture('previousLightTex', previousLight);
+    renderPass.setTexture('previousPositionTex', previousPosition);
 
     renderPass.useProgram();
     fullscreenQuad.draw();

--- a/src/renderer/ToneMapPass.js
+++ b/src/renderer/ToneMapPass.js
@@ -46,8 +46,8 @@ export function makeToneMapPass(gl, params) {
       renderPassNative;
 
     renderPass.setUniform('lightScale', lightScale.x, lightScale.y);
-    renderPass.setTexture('light', light);
-    renderPass.setTexture('position', position);
+    renderPass.setTexture('lightTex', light);
+    renderPass.setTexture('positionTex', position);
 
     renderPass.useProgram();
     fullscreenQuad.draw();

--- a/src/renderer/envMapDistribution.js
+++ b/src/renderer/envMapDistribution.js
@@ -1,7 +1,7 @@
-// Create a piecewise 2D cumulative distribution function of light intensity from an envmap
+// Create a piecewise 2D cumulative distribution function of light intensity from an env map
 // http://www.pbr-book.org/3ed-2018/Monte_Carlo_Integration/2D_Sampling_with_Multidimensional_Transformations.html#Piecewise-Constant2DDistributions
 
-export function envmapDistribution(image) {
+export function envMapDistribution(image) {
   const data = image.data;
 
   const cdfImage = {

--- a/src/renderer/glsl/chunks/envMap.glsl
+++ b/src/renderer/glsl/chunks/envMap.glsl
@@ -3,8 +3,8 @@
 
 export default `
 
-uniform sampler2D envmap;
-uniform sampler2D envmapDistribution;
+uniform sampler2D envMap;
+uniform sampler2D envMapDistribution;
 uniform sampler2D backgroundMap;
 
 vec2 cartesianToEquirect(vec3 pointOnSphere) {
@@ -14,13 +14,13 @@ vec2 cartesianToEquirect(vec3 pointOnSphere) {
 }
 
 float getEnvmapV(float u, out int vOffset, out float pdf) {
-  ivec2 size = textureSize(envmap, 0);
+  ivec2 size = textureSize(envMap, 0);
 
   int left = 0;
-  int right = size.y + 1; // cdf length is the length of the envmap + 1
+  int right = size.y + 1; // cdf length is the length of the env map + 1
   while (left < right) {
     int mid = (left + right) >> 1;
-    float s = texelFetch(envmapDistribution, ivec2(0, mid), 0).x;
+    float s = texelFetch(envMapDistribution, ivec2(0, mid), 0).x;
     if (s <= u) {
       left = mid + 1;
     } else {
@@ -29,10 +29,10 @@ float getEnvmapV(float u, out int vOffset, out float pdf) {
   }
   vOffset = left - 1;
 
-  // x channel is cumulative distribution of envmap luminance
-  // y channel is partial probability density of envmap luminance
-  vec2 s0 = texelFetch(envmapDistribution, ivec2(0, vOffset), 0).xy;
-  vec2 s1 = texelFetch(envmapDistribution, ivec2(0, vOffset + 1), 0).xy;
+  // x channel is cumulative distribution of env map luminance
+  // y channel is partial probability density of env map luminance
+  vec2 s0 = texelFetch(envMapDistribution, ivec2(0, vOffset), 0).xy;
+  vec2 s1 = texelFetch(envMapDistribution, ivec2(0, vOffset + 1), 0).xy;
 
   pdf = s0.y;
 
@@ -40,13 +40,13 @@ float getEnvmapV(float u, out int vOffset, out float pdf) {
 }
 
 float getEnvmapU(float u, int vOffset, out float pdf) {
-  ivec2 size = textureSize(envmap, 0);
+  ivec2 size = textureSize(envMap, 0);
 
   int left = 0;
-  int right = size.x + 1; // cdf length is the length of the envmap + 1
+  int right = size.x + 1; // cdf length is the length of the env map + 1
   while (left < right) {
     int mid = (left + right) >> 1;
-    float s = texelFetch(envmapDistribution, ivec2(1 + mid, vOffset), 0).x;
+    float s = texelFetch(envMapDistribution, ivec2(1 + mid, vOffset), 0).x;
     if (s <= u) {
       left = mid + 1;
     } else {
@@ -55,10 +55,10 @@ float getEnvmapU(float u, int vOffset, out float pdf) {
   }
   int uOffset = left - 1;
 
-  // x channel is cumulative distribution of envmap luminance
-  // y channel is partial probability density of envmap luminance
-  vec2 s0 = texelFetch(envmapDistribution, ivec2(1 + uOffset, vOffset), 0).xy;
-  vec2 s1 = texelFetch(envmapDistribution, ivec2(1 + uOffset + 1, vOffset), 0).xy;
+  // x channel is cumulative distribution of env map luminance
+  // y channel is partial probability density of env map luminance
+  vec2 s0 = texelFetch(envMapDistribution, ivec2(1 + uOffset, vOffset), 0).xy;
+  vec2 s1 = texelFetch(envMapDistribution, ivec2(1 + uOffset + 1, vOffset), 0).xy;
 
   pdf = s0.y;
 
@@ -87,22 +87,22 @@ vec3 sampleEnvmap(vec2 random, out vec2 uv, out float pdf) {
   return dir;
 }
 
-float envmapPdf(vec2 uv) {
-  vec2 size = vec2(textureSize(envmap, 0));
+float envMapPdf(vec2 uv) {
+  vec2 size = vec2(textureSize(envMap, 0));
 
   float sinTheta = sin(uv.y * PI);
 
   uv *= size;
 
-  float partialX = texelFetch(envmapDistribution, ivec2(1.0 + uv.x, uv.y), 0).y;
-  float partialY = texelFetch(envmapDistribution, ivec2(0, uv.y), 0).y;
+  float partialX = texelFetch(envMapDistribution, ivec2(1.0 + uv.x, uv.y), 0).y;
+  float partialY = texelFetch(envMapDistribution, ivec2(0, uv.y), 0).y;
 
   return partialX * partialY * INVPI2 / (2.0 * sinTheta);
 }
 
 vec3 sampleEnvmapFromDirection(vec3 d) {
   vec2 uv = cartesianToEquirect(d);
-  return textureLinear(envmap, uv).rgb;
+  return textureLinear(envMap, uv).rgb;
 }
 
 vec3 sampleBackgroundFromDirection(vec3 d) {

--- a/src/renderer/glsl/chunks/random.glsl
+++ b/src/renderer/glsl/chunks/random.glsl
@@ -2,7 +2,7 @@ export default `
 
 // Noise texture used to generate a different random number for each pixel.
 // We use blue noise in particular, but any type of noise will work.
-uniform sampler2D noise;
+uniform sampler2D noiseTex;
 
 uniform float stratifiedSamples[SAMPLING_DIMENSIONS];
 uniform float strataSize;
@@ -15,10 +15,10 @@ int sampleIndex = 0;
 float pixelSeed;
 
 void initRandom() {
-  vec2 noiseSize = vec2(textureSize(noise, 0));
+  vec2 noiseSize = vec2(textureSize(noiseTex, 0));
 
   // tile the small noise texture across the entire screen
-  pixelSeed = texture(noise, vCoord / (pixelSize * noiseSize)).r;
+  pixelSeed = texture(noiseTex, vCoord / (pixelSize * noiseSize)).r;
 }
 
 float randomSample() {

--- a/src/renderer/glsl/chunks/sampleGlassMicrofacet.glsl
+++ b/src/renderer/glsl/chunks/sampleGlassMicrofacet.glsl
@@ -88,7 +88,7 @@ vec3 glassImportanceSampleLight(SurfaceInteraction si, vec3 viewDir, bool lightR
     return li;
   }
 
-  vec3 irr = textureLinear(envmap, uv).xyz;
+  vec3 irr = textureLinear(envMap, uv).xyz;
 
   float scatteringPdf;
   vec3 brdf = lightRefract ?
@@ -119,9 +119,9 @@ vec3 glassImportanceSampleMaterial(SurfaceInteraction si, vec3 viewDir, bool lig
   }
 
   vec2 uv = cartesianToEquirect(lightDir);
-  float lightPdf = envmapPdf(uv);
+  float lightPdf = envMapPdf(uv);
 
-  vec3 irr = textureLinear(envmap, vec2(phi, theta)).rgb;
+  vec3 irr = textureLinear(envMap, vec2(phi, theta)).rgb;
 
   float scatteringPdf;
   vec3 brdf = lightRefract ?

--- a/src/renderer/glsl/chunks/sampleMaterial.glsl
+++ b/src/renderer/glsl/chunks/sampleMaterial.glsl
@@ -30,7 +30,7 @@ void sampleMaterial(SurfaceInteraction si, int bounce, inout Path path) {
       lightDirSpecular(si.faceNormal, viewDir, basis, si.roughness, lightDirSample);
 
     uv = cartesianToEquirect(lightDir);
-    lightPdf = envmapPdf(uv);
+    lightPdf = envMapPdf(uv);
     brdfSample = true;
   } else {
     lightDir = sampleEnvmap(lightDirSample, uv, lightPdf);
@@ -57,7 +57,7 @@ void sampleMaterial(SurfaceInteraction si, int bounce, inout Path path) {
     }
   }
 
-  vec3 irr = textureLinear(envmap, uv).rgb;
+  vec3 irr = textureLinear(envMap, uv).rgb;
 
   float scatteringPdf;
   vec3 brdf = materialBrdf(si, viewDir, lightDir, cosThetaL, diffuseWeight, scatteringPdf);
@@ -95,7 +95,7 @@ void sampleMaterial(SurfaceInteraction si, int bounce, inout Path path) {
   brdf = materialBrdf(si, viewDir, lightDir, cosThetaL, 1.0, scatteringPdf);
 
   uv = cartesianToEquirect(lightDir);
-  lightPdf = envmapPdf(uv);
+  lightPdf = envMapPdf(uv);
 
   path.misWeight = powerHeuristic(scatteringPdf, lightPdf);
 

--- a/src/renderer/glsl/chunks/sampleShadowCatcher.glsl
+++ b/src/renderer/glsl/chunks/sampleShadowCatcher.glsl
@@ -26,7 +26,7 @@ void sampleShadowCatcher(SurfaceInteraction si, int bounce, inout Path path) {
       lightDirDiffuse(si.faceNormal, viewDir, basis, lightDirSample) :
       lightDirSpecular(si.faceNormal, viewDir, basis, si.roughness, lightDirSample);
     uv = cartesianToEquirect(lightDir);
-    lightPdf = envmapPdf(uv);
+    lightPdf = envMapPdf(uv);
     brdfSample = true;
   } else {
     lightDir = sampleEnvmap(lightDirSample, uv, lightPdf);
@@ -47,7 +47,7 @@ void sampleShadowCatcher(SurfaceInteraction si, int bounce, inout Path path) {
     occluded = 0.0;
   }
 
-  float irr = dot(luminance, textureLinear(envmap, uv).rgb);
+  float irr = dot(luminance, textureLinear(envMap, uv).rgb);
 
   float scatteringPdf;
   vec3 brdf = materialBrdf(si, viewDir, lightDir, cosThetaL, 1.0, scatteringPdf);
@@ -84,7 +84,7 @@ void sampleShadowCatcher(SurfaceInteraction si, int bounce, inout Path path) {
   brdf = materialBrdf(si, viewDir, lightDir, cosThetaL, 1.0, scatteringPdf);
 
   uv = cartesianToEquirect(lightDir);
-  lightPdf = envmapPdf(uv);
+  lightPdf = envMapPdf(uv);
 
   path.misWeight = 0.0;
 

--- a/src/renderer/glsl/rayTrace.frag
+++ b/src/renderer/glsl/rayTrace.frag
@@ -6,7 +6,7 @@ import materialBuffer from './chunks/materialBuffer.glsl';
 import intersect from './chunks/intersect.glsl';
 import surfaceInteractionDirect from './chunks/surfaceInteractionDirect.glsl';
 import random from './chunks/random.glsl';
-import envmap from './chunks/envmap.glsl';
+import envMap from './chunks/envMap.glsl';
 import bsdf from './chunks/bsdf.glsl';
 import sample from './chunks/sample.glsl';
 import sampleMaterial from './chunks/sampleMaterial.glsl';
@@ -22,7 +22,7 @@ includes: [
   intersect,
   surfaceInteractionDirect,
   random,
-  envmap,
+  envMap,
   bsdf,
   sample,
   sampleMaterial,

--- a/src/renderer/glsl/reproject.frag
+++ b/src/renderer/glsl/reproject.frag
@@ -6,13 +6,13 @@ includes: [textureLinear],
 source: `
   in vec2 vCoord;
 
-  uniform mediump sampler2D light;
-  uniform mediump sampler2D position;
+  uniform mediump sampler2D lightTex;
+  uniform mediump sampler2D positionTex;
   uniform vec2 lightScale;
   uniform vec2 previousLightScale;
 
-  uniform mediump sampler2D previousLight;
-  uniform mediump sampler2D previousPosition;
+  uniform mediump sampler2D previousLightTex;
+  uniform mediump sampler2D previousPositionTex;
 
   uniform mat4 historyCamera;
   uniform float blendAmount;
@@ -28,10 +28,10 @@ source: `
   }
 
   void main() {
-    vec3 currentPosition = textureLinear(position, vCoord).xyz;
-    float currentMeshId = getMeshId(position, vCoord);
+    vec3 currentPosition = textureLinear(positionTex, vCoord).xyz;
+    float currentMeshId = getMeshId(positionTex, vCoord);
 
-    vec4 currentLight = texture(light, lightScale * vCoord);
+    vec4 currentLight = texture(lightTex, lightScale * vCoord);
 
     if (currentMeshId == 0.0) {
       out_light = currentLight;
@@ -40,7 +40,7 @@ source: `
 
     vec2 hCoord = reproject(currentPosition) - jitter;
 
-    vec2 hSizef = previousLightScale * vec2(textureSize(previousLight, 0));
+    vec2 hSizef = previousLightScale * vec2(textureSize(previousLightTex, 0));
     vec2 hSizeInv = 1.0 / hSizef;
     ivec2 hSize = ivec2(hSizef);
 
@@ -69,12 +69,12 @@ source: `
     for (int i = 0; i < 4; i++) {
       vec2 gCoord = (vec2(texel[i]) + 0.5) * hSizeInv;
 
-      float histMeshId = getMeshId(previousPosition, gCoord);
+      float histMeshId = getMeshId(previousPositionTex, gCoord);
 
       float isValid = histMeshId != currentMeshId || any(greaterThanEqual(texel[i], hSize)) ? 0.0 : 1.0;
 
       float weight = isValid * weights[i];
-      history += weight * texelFetch(previousLight, texel[i], 0);
+      history += weight * texelFetch(previousLightTex, texel[i], 0);
       sum += weight;
     }
 
@@ -89,12 +89,12 @@ source: `
           ivec2 texel = hTexel + ivec2(x, y);
           vec2 gCoord = (vec2(texel) + 0.5) * hSizeInv;
 
-          float histMeshId = getMeshId(previousPosition, gCoord);
+          float histMeshId = getMeshId(previousPositionTex, gCoord);
 
           float isValid = histMeshId != currentMeshId || any(greaterThanEqual(texel, hSize)) ? 0.0 : 1.0;
 
           float weight = isValid;
-          vec4 h = texelFetch(previousLight, texel, 0);
+          vec4 h = texelFetch(previousLightTex, texel, 0);
           history += weight * h;
           sum += weight;
         }

--- a/src/renderer/glsl/toneMap.frag
+++ b/src/renderer/glsl/toneMap.frag
@@ -97,7 +97,7 @@ source: `
     // divide the sum of light by alpha to obtain average contribution of light
 
     // in addition, alpha contains a scale factor for the shadow catcher material
-    // dividing by alpha normalizes the brightness of the shadow catcher to match the background envMap.
+    // dividing by alpha normalizes the brightness of the shadow catcher to match the background env map.
     vec3 light = upscaledLight.rgb / upscaledLight.a;
 
     light *= EXPOSURE;


### PR DESCRIPTION
## Brief Description
Simple variable change that makes the shader code more consistent.

1. Any sampler2D that maps to a 3D mesh is renamed to [x]Map
2. Any sampler2D that represents an arbitrary 2D texture (not mapped to any mesh) is renamed to [x]Tex
3. Any sampler2D that packs 1D data to be called with `fetchData` is renamed to [x]Buffer
4. Renames `envmap` to `envMap` because environment map is two words, and this change makes it consistent with 1.
## Pull Request Guidelines
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] I have added pull requests labels which describe my contribution.
- [x] All existing tests passed.
    - [ ] I have added tests to cover my changes, of which pass.
- [x] I have [compared](https://github.com/hoverinc/ray-tracing-renderer/wiki/Contributing#comparing-changes) the render output of my branch to `master`.
- [x] My code has passed the ESLint configuration for this project.
- [ ] My change requires modifications to the documentation.
    - [ ] I have updated the documentation accordingly.
