### PR TITLE
renderer.onSampleRendered returns time elapsed between samples

### DIFF
--- a/src/renderer/RenderingPipeline.js
+++ b/src/renderer/RenderingPipeline.js
@@ -67,6 +67,7 @@ export function makeRenderingPipeline({
 
   let frameTime;
   let elapsedFrameTime;
+  let sampleTime;
 
   let sampleCount = 0;
   let numPreviewsRendered = 0;
@@ -311,6 +312,9 @@ export function makeRenderingPipeline({
       if (sampleCount === 0) { // previous rendered image was a preview image
         clearBuffer(hdrBuffer);
         reprojectPass.setPreviousCamera(lastCamera);
+      } else {
+        sampleRenderedCallback(sampleCount, frameTime - sampleTime || NaN);
+        sampleTime = frameTime;
       }
 
       updateSeed(screenWidth, screenHeight, true);
@@ -344,8 +348,6 @@ export function makeRenderingPipeline({
       } else {
         toneMapToScreen(hdrBuffer.color[0], fullscreenScale);
       }
-
-      sampleRenderedCallback(sampleCount);
     }
   }
 


### PR DESCRIPTION
## Brief Description
To be used as a way to measure performance.

Note: The timeElapsed argument will be `NaN` whenever an elapsed time can't be computed (for the first frame, or whenever the user switches between tabs while the renderer is running)

## Pull Request Guidelines
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] I have added pull requests labels which describe my contribution.
- [x] All existing tests passed.
    - [ ] I have added tests to cover my changes, of which pass.
- [x] I have [compared](https://github.com/hoverinc/ray-tracing-renderer/wiki/Contributing#comparing-changes) the render output of my branch to `master`.
- [x] My code has passed the ESLint configuration for this project.
- [x] My change requires modifications to the documentation.
    - [] I have updated the documentation accordingly.
