### PR TITLE
Fix recursive loop in BVH building

### DIFF
--- a/build/RayTracingRenderer.es5.js
+++ b/build/RayTracingRenderer.es5.js
@@ -2006,7 +2006,12 @@
           }
 
           return b <= minCostSplitBucket;
-        }, start, end);
+        }, start, end); // Avoid a recursive loop
+        // This happens when all primitive centroids are equal
+
+        if (mid > end) {
+          return makeLeafNode(primitiveInfo.slice(start, end), bounds);
+        }
       }
 
       return makeInteriorNode(dim, recursiveBuild(primitiveInfo, start, mid), recursiveBuild(primitiveInfo, mid, end));

--- a/build/RayTracingRenderer.js
+++ b/build/RayTracingRenderer.js
@@ -1730,6 +1730,12 @@ vec3 getMatNormal(int materialIndex, vec2 uv, vec3 normal, vec3 dp1, vec3 dp2, v
           }
           return b <= minCostSplitBucket;
         }, start, end);
+        
+        // Avoid a recursive loop
+        // This happens when all primitive centroids are equal
+        if ( mid > end) {
+          return makeLeafNode(primitiveInfo.slice(start, end), bounds);
+        }
       }
 
       return makeInteriorNode(

--- a/src/renderer/bvhAccel.js
+++ b/src/renderer/bvhAccel.js
@@ -218,7 +218,7 @@ function recursiveBuild(primitiveInfo, start, end) {
       
       // Avoid a recursive loop
       // This happens when all primitive centroids are equal
-      if ( mid+1 >= end) {
+      if ( mid > end) {
         return makeLeafNode(primitiveInfo.slice(start, end), bounds);
       }
     }

--- a/src/renderer/bvhAccel.js
+++ b/src/renderer/bvhAccel.js
@@ -215,6 +215,12 @@ function recursiveBuild(primitiveInfo, start, end) {
         }
         return b <= minCostSplitBucket;
       }, start, end);
+      
+      // Avoid a recursive loop
+      // This happens when all primitive centroids are equal
+      if ( mid+1 >= end) {
+        return makeLeafNode(primitiveInfo.slice(start, end), bounds);
+      }
     }
 
     return makeInteriorNode(


### PR DESCRIPTION
## Brief Description
When all primitive centroids are equal during a recursive BVH building step, it results in a recursive loop.
This fix detects this case and returns a leaf node instead.

## Pull Request Guidelines
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] I have added pull requests labels which describe my contribution.
- [x] All existing tests passed.
    - [ ] I have added tests to cover my changes, of which pass.
- [x] I have [compared](https://github.com/hoverinc/ray-tracing-renderer/wiki/Contributing#comparing-changes) the render output of my branch to `master`.
- [ ] My code has passed the ESLint configuration for this project.
- [ ] My change requires modifications to the documentation.
    - [ ] I have updated the documentation accordingly.
