### PR TITLE
Fix recursive loop in BVH building

### DIFF
--- a/src/renderer/bvhAccel.js
+++ b/src/renderer/bvhAccel.js
@@ -149,6 +149,10 @@ function recursiveBuild(primitiveInfo, start, end) {
     }
     const dim = maximumExtent(centroidBounds);
 
+    if (centroidBounds.max[dim] === centroidBounds.min[dim]) {
+      return makeLeafNode(primitiveInfo.slice(start, end), bounds);
+    }
+
     let mid = Math.floor((start + end) / 2);
 
     // middle split method


### PR DESCRIPTION
## Brief Description
When all primitive centroids are equal during a recursive BVH building step, it results in a recursive loop.
This fix detects this case and returns a leaf node instead.

## Pull Request Guidelines
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] I have added pull requests labels which describe my contribution.
- [x] All existing tests passed.
    - [ ] I have added tests to cover my changes, of which pass.
- [x] I have [compared](https://github.com/hoverinc/ray-tracing-renderer/wiki/Contributing#comparing-changes) the render output of my branch to `master`.
- [x] My code has passed the ESLint configuration for this project.
- [ ] My change requires modifications to the documentation.
    - [ ] I have updated the documentation accordingly.
