### PR TITLE
Fix incorrect BVH

### DIFF
--- a/scenes/renderer-test/main.js
+++ b/scenes/renderer-test/main.js
@@ -196,6 +196,32 @@ function init() {
     model.add(mesh);
   }
 
+  let unreadyMat;
+  {
+    // Create a test (non-buffer) Geometry
+    const geo = new THREE.BoxGeometry(20, 6, 6);
+    const mat = new THREE.MeshStandardMaterial();
+    mat.roughness = 0.2;
+    mat.metalness = 0.0;
+    mat.color.set(0x993311);
+    unreadyMat = mat;
+    const mesh = new THREE.Mesh(geo, mat);
+    mesh.position.set(0, 3, 30);
+    model.add(mesh);
+  }
+
+  // background mirror
+  // verifies BVH used in reflections
+  {
+    const geo = new THREE.PlaneBufferGeometry(40, 16);
+    const mat = new THREE.MeshStandardMaterial();
+    mat.roughness = 0.0;
+    mat.metalness = 1.0;
+    const mesh = new THREE.Mesh(geo, mat);
+    mesh.position.set(0, 8, 40);
+    model.add(mesh);
+  }
+
   // ground plane
   {
     const geo = new THREE.PlaneBufferGeometry(1000, 1000);
@@ -216,20 +242,6 @@ function init() {
     const mesh = new THREE.Mesh(geo, mat);
     mesh.position.set(0, 10, 0);
     mesh.visible = false;
-    model.add(mesh);
-  }
-
-  let unreadyMat;
-  {
-    // Create a test (non-buffer) Geometry
-    const geo = new THREE.BoxGeometry(6, 6, 6);
-    const mat = new THREE.MeshStandardMaterial();
-    mat.roughness = 0.2;
-    mat.metalness = 0.0;
-    mat.color.set(0x993311);
-    unreadyMat = mat;
-    const mesh = new THREE.Mesh(geo, mat);
-    mesh.position.set(0, 3, 30);
     model.add(mesh);
   }
 

--- a/src/renderer/bvhAccel.js
+++ b/src/renderer/bvhAccel.js
@@ -149,9 +149,6 @@ function recursiveBuild(primitiveInfo, start, end) {
     }
     const dim = maximumExtent(centroidBounds);
 
-    if (centroidBounds.max[dim] === centroidBounds.min[dim]) {
-      return makeLeafNode(primitiveInfo.slice(start, end), bounds);
-    }
 
     let mid = Math.floor((start + end) / 2);
 
@@ -167,7 +164,11 @@ function recursiveBuild(primitiveInfo, start, end) {
     // surface area heuristic method
     if (nPrimitives <= 4) {
       nthElement(primitiveInfo, (a, b) => a.center[dim] < b.center[dim], start, end, mid);
+    } else if (centroidBounds.max[dim] === centroidBounds.min[dim]) {
+      // can't split nodes based on centroids. terminate.
+      return makeLeafNode(primitiveInfo.slice(start, end), bounds);
     } else {
+
       const buckets = [];
       for (let i = 0; i < 12; i++) {
         buckets.push({

--- a/src/renderer/bvhAccel.js
+++ b/src/renderer/bvhAccel.js
@@ -165,7 +165,7 @@ function recursiveBuild(primitiveInfo, start, end) {
     if (nPrimitives <= 4) {
       nthElement(primitiveInfo, (a, b) => a.center[dim] < b.center[dim], start, end, mid);
     } else if (centroidBounds.max[dim] === centroidBounds.min[dim]) {
-      // can't split nodes based on centroids. terminate.
+      // can't split primitives based on centroid bounds. terminate.
       return makeLeafNode(primitiveInfo.slice(start, end), bounds);
     } else {
 


### PR DESCRIPTION
## Brief Description
Fixes incorrect BVH generation as experienced in https://github.com/hoverinc/ray-tracing-renderer/issues/92.

There are certain cases where the centroid bounds can be zero but the BVH can still be partitioned. This special case is not present in the test scene, but it is preset in the readme scene with the flight mask. This PR makes the bounds check to happen only if trying to partition using the SAH and not nthElement.

This change definitely fixes the incorrect BVH, but it may re-introduce infinite loops. I have no way of testing this since I don't have access to a problematic model, and I'm not sure how to generate one. Would you have any ideas @ToJans ?

## Image(s) or GIFs (if applicable)
Before: 
![Screenshot from 2020-05-08 12-54-07](https://user-images.githubusercontent.com/4411068/81443920-2777b800-912b-11ea-8e0d-290e9ec4f10e.png)

After: 
![Screenshot from 2020-05-08 12-53-18](https://user-images.githubusercontent.com/4411068/81443922-28a8e500-912b-11ea-9543-cef418d9809d.png)


## Pull Request Guidelines
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] I have added pull requests labels which describe my contribution.
- [x] All existing tests passed.
    - [x] I have added tests to cover my changes, of which pass.
- [x] I have [compared](https://github.com/hoverinc/ray-tracing-renderer/wiki/Contributing#comparing-changes) the render output of my branch to `master`.
- [x] My code has passed the ESLint configuration for this project.
- [ ] My change requires modifications to the documentation.
    - [ ] I have updated the documentation accordingly.
