### PR TITLE
Reprojection for spatial denoising

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -1,3 +1,4 @@
-export const ThinMaterial = 1;
-export const ThickMaterial = 2;
-export const ShadowCatcherMaterial = 3;
+export const StandardMaterial = 1;
+export const ThinMaterial = 2;
+export const ThickMaterial = 3;
+export const ShadowCatcherMaterial = 4;

--- a/src/renderer/MaterialBuffer.js
+++ b/src/renderer/MaterialBuffer.js
@@ -1,4 +1,4 @@
-import { ThinMaterial, ThickMaterial, ShadowCatcherMaterial } from '../constants';
+import { StandardMaterial, ThinMaterial, ThickMaterial, ShadowCatcherMaterial } from '../constants';
 import materialBufferChunk from './glsl/chunks/materialBuffer.glsl';
 import { makeUniformBuffer } from './UniformBuffer';
 import { makeRenderPass } from "./RenderPass";
@@ -24,9 +24,10 @@ export function makeMaterialBuffer(gl, materials) {
   bufferData.type = materials.map(m => {
     if (m.shadowCatcher) {
       return ShadowCatcherMaterial;
-    }
-    if (m.transparent) {
+    } else if (m.transparent) {
       return m.solid ? ThickMaterial : ThinMaterial;
+    } else {
+      return StandardMaterial;
     }
   });
 

--- a/src/renderer/RenderSize.js
+++ b/src/renderer/RenderSize.js
@@ -56,7 +56,7 @@ export function makeRenderSize(gl) {
 
 function pixelsPerFrameEstimate(gl) {
   const maxRenderbufferSize = gl.getParameter(gl.MAX_RENDERBUFFER_SIZE);
-  return 50000;
+  return 40000;
   if (maxRenderbufferSize <= 8192) {
     return 80000;
   } else if (maxRenderbufferSize === 16384) {

--- a/src/renderer/RenderSize.js
+++ b/src/renderer/RenderSize.js
@@ -56,7 +56,7 @@ export function makeRenderSize(gl) {
 
 function pixelsPerFrameEstimate(gl) {
   const maxRenderbufferSize = gl.getParameter(gl.MAX_RENDERBUFFER_SIZE);
-  return 40000;
+
   if (maxRenderbufferSize <= 8192) {
     return 80000;
   } else if (maxRenderbufferSize === 16384) {

--- a/src/renderer/RenderSize.js
+++ b/src/renderer/RenderSize.js
@@ -56,7 +56,7 @@ export function makeRenderSize(gl) {
 
 function pixelsPerFrameEstimate(gl) {
   const maxRenderbufferSize = gl.getParameter(gl.MAX_RENDERBUFFER_SIZE);
-
+  return 50000;
   if (maxRenderbufferSize <= 8192) {
     return 80000;
   } else if (maxRenderbufferSize === 16384) {

--- a/src/renderer/RenderingPipeline.js
+++ b/src/renderer/RenderingPipeline.js
@@ -126,7 +126,7 @@ export function makeRenderingPipeline({
     reprojectBuffer = makeHdrBuffer(reprojectPass.outputLocs);
     reprojectBackBuffer = makeHdrBuffer(reprojectPass.outputLocs);
 
-    const normalBuffer = makeTexture(gl, { width, height, storage: 'halfFloat' });
+    // const normalBuffer = makeTexture(gl, { width, height, storage: 'halfFloat' });
     const faceNormalBuffer = makeTexture(gl, { width, height, storage: 'halfFloat' });
     const albedoBuffer = makeTexture(gl, { width, height, storage: 'byte', channels: 4});
     const matProps = makeTexture(gl, { width, height, storage: 'byte', channels: 2 });
@@ -135,6 +135,7 @@ export function makeRenderingPipeline({
 
     function makeGBuffer() {
       const positionBuffer = makeTexture(gl, { width, height, storage: 'float' });
+      const normalBuffer = makeTexture(gl, { width, height, storage: 'halfFloat' });
 
       return makeFramebuffer(gl, {
         colorAttachments: [
@@ -307,10 +308,12 @@ export function makeRenderingPipeline({
       light: hdrBuffer.color[0],
       lightScale,
       position: gBuffer.color[gBufferPass.outputLocs.position],
+      normal: gBuffer.color[gBufferPass.outputLocs.normal],
       matProps: gBuffer.color[gBufferPass.outputLocs.matProps],
       previousLight,
       previousLightScale,
       previousPosition: gBufferBack.color[gBufferPass.outputLocs.position],
+      previousNormal: gBufferBack.color[gBufferPass.outputLocs.normal],
       reprojectPosition
     });
     reprojectBuffer.unbind();
@@ -341,9 +344,9 @@ export function makeRenderingPipeline({
       swapBuffers();
     }
 
-    if (numPreviewsRendered >= previewFramesBeforeBenchmark) {
-      previewSize.adjustSize(elapsedFrameTime);
-    }
+    // if (numPreviewsRendered >= previewFramesBeforeBenchmark) {
+    //   previewSize.adjustSize(elapsedFrameTime);
+    // }
 
     updateSeed(previewSize, false);
 
@@ -474,7 +477,7 @@ export function makeRenderingPipeline({
 
   return {
     draw,
-    drawFull,
+    drawFull: draw,
     setSize,
     sync,
     getTotalSamplesRendered() {

--- a/src/renderer/RenderingPipeline.js
+++ b/src/renderer/RenderingPipeline.js
@@ -345,9 +345,9 @@ export function makeRenderingPipeline({
       swapBuffers();
     }
 
-    // if (numPreviewsRendered >= previewFramesBeforeBenchmark) {
-    //   previewSize.adjustSize(elapsedFrameTime);
-    // }
+    if (numPreviewsRendered >= previewFramesBeforeBenchmark) {
+      previewSize.adjustSize(elapsedFrameTime);
+    }
 
     updateSeed(previewSize, false);
 
@@ -403,7 +403,7 @@ export function makeRenderingPipeline({
           lightScale: fullscreenScale,
           previousLight: reprojectBackBuffer.color[0],
           previousLightScale: previewSize.scale,
-          // reprojectPosition: sampleCount <= 1 // Only blend frames and don't reproject positions after camera stays still
+          reprojectPosition: sampleCount <= 1 // Only blend frames and don't reproject positions after camera stays still
         });
 
         toneMapToScreen(reprojectBuffer.color[0], fullscreenScale);

--- a/src/renderer/RenderingPipeline.js
+++ b/src/renderer/RenderingPipeline.js
@@ -127,7 +127,7 @@ export function makeRenderingPipeline({
     reprojectBackBuffer = makeHdrBuffer(reprojectPass.outputLocs);
 
     // const normalBuffer = makeTexture(gl, { width, height, storage: 'halfFloat' });
-    const faceNormalBuffer = makeTexture(gl, { width, height, storage: 'halfFloat' });
+    // const faceNormalBuffer = makeTexture(gl, { width, height, storage: 'halfFloat' });
     const albedoBuffer = makeTexture(gl, { width, height, storage: 'byte', channels: 4});
     const matProps = makeTexture(gl, { width, height, storage: 'byte', channels: 2 });
 
@@ -136,6 +136,7 @@ export function makeRenderingPipeline({
     function makeGBuffer() {
       const positionBuffer = makeTexture(gl, { width, height, storage: 'float' });
       const normalBuffer = makeTexture(gl, { width, height, storage: 'halfFloat' });
+      const faceNormalBuffer = makeTexture(gl, { width, height, storage: 'halfFloat' });
 
       return makeFramebuffer(gl, {
         colorAttachments: [
@@ -308,12 +309,12 @@ export function makeRenderingPipeline({
       light: hdrBuffer.color[0],
       lightScale,
       position: gBuffer.color[gBufferPass.outputLocs.position],
-      normal: gBuffer.color[gBufferPass.outputLocs.normal],
+      normal: gBuffer.color[gBufferPass.outputLocs.faceNormal],
       matProps: gBuffer.color[gBufferPass.outputLocs.matProps],
       previousLight,
       previousLightScale,
       previousPosition: gBufferBack.color[gBufferPass.outputLocs.position],
-      previousNormal: gBufferBack.color[gBufferPass.outputLocs.normal],
+      previousNormal: gBufferBack.color[gBufferPass.outputLocs.faceNormal],
       reprojectPosition
     });
     reprojectBuffer.unbind();

--- a/src/renderer/RenderingPipeline.js
+++ b/src/renderer/RenderingPipeline.js
@@ -37,7 +37,7 @@ export function makeRenderingPipeline({
 
   // tile rendering can cause the GPU to stutter, throwing off future benchmarks for the preview frames
   // wait to measure performance until this number of frames have been rendered
-  const previewFramesBeforeBenchmark = 2;
+  const previewFramesBeforeBenchmark = 3;
 
   // used to sample only a portion of the scene to the HDR Buffer to prevent the GPU from locking up from excessive computation
   const tileRender = makeTileRender(gl);
@@ -126,7 +126,7 @@ export function makeRenderingPipeline({
     reprojectBuffer = makeHdrBuffer(reprojectPass.outputLocs);
     reprojectBackBuffer = makeHdrBuffer(reprojectPass.outputLocs);
 
-    // const normalBuffer = makeTexture(gl, { width, height, storage: 'halfFloat' });
+    const normalBuffer = makeTexture(gl, { width, height, storage: 'halfFloat' });
     // const faceNormalBuffer = makeTexture(gl, { width, height, storage: 'halfFloat' });
     const albedoBuffer = makeTexture(gl, { width, height, storage: 'byte', channels: 4});
     const matProps = makeTexture(gl, { width, height, storage: 'byte', channels: 2 });
@@ -135,7 +135,7 @@ export function makeRenderingPipeline({
 
     function makeGBuffer() {
       const positionBuffer = makeTexture(gl, { width, height, storage: 'float' });
-      const normalBuffer = makeTexture(gl, { width, height, storage: 'halfFloat' });
+      // const normalBuffer = makeTexture(gl, { width, height, storage: 'halfFloat' });
       const faceNormalBuffer = makeTexture(gl, { width, height, storage: 'halfFloat' });
 
       return makeFramebuffer(gl, {
@@ -333,6 +333,7 @@ export function makeRenderingPipeline({
       light: lightTexture,
       lightScale,
       position: gBuffer.color[gBufferPass.outputLocs.position],
+      normal: gBuffer.color[gBufferPass.outputLocs.faceNormal],
       diffuseSpecularAlbedo: diffuseSpecularAlbedoBuffer.color[0],
     });
 
@@ -403,7 +404,7 @@ export function makeRenderingPipeline({
           lightScale: fullscreenScale,
           previousLight: reprojectBackBuffer.color[0],
           previousLightScale: previewSize.scale,
-          reprojectPosition: sampleCount === 0 // Only blend frames and don't reproject positions after camera stays still
+          // reprojectPosition: sampleCount <= 1 // Only blend frames and don't reproject positions after camera stays still
         });
 
         toneMapToScreen(reprojectBuffer.color[0], fullscreenScale);

--- a/src/renderer/ReprojectPass.js
+++ b/src/renderer/ReprojectPass.js
@@ -43,10 +43,12 @@ export function makeReprojectPass(gl, params) {
       light,
       lightScale,
       position,
+      normal,
       matProps,
       previousLight,
       previousLightScale,
       previousPosition,
+      previousNormal,
       reprojectPosition,
     } = params;
 
@@ -60,9 +62,12 @@ export function makeReprojectPass(gl, params) {
 
     renderPass.setTexture('diffuseSpecularTex', light);
     renderPass.setTexture('positionTex', position);
+    renderPass.setTexture('normalTex', normal);
     renderPass.setTexture('matPropsTex', matProps);
+
     renderPass.setTexture('previousDiffuseSpecularTex', previousLight);
     renderPass.setTexture('previousPositionTex', previousPosition);
+    renderPass.setTexture('previousNormalTex', previousNormal);
 
     renderPass.useProgram();
     fullscreenQuad.draw();

--- a/src/renderer/ToneMapPass.js
+++ b/src/renderer/ToneMapPass.js
@@ -36,12 +36,14 @@ export function makeToneMapPass(gl, params) {
       lightScale,
       diffuseSpecularAlbedo,
       position,
+      normal,
     } = params;
 
     renderPass.setUniform('edgeAwareUpscale', lightScale.x < 1 || lightScale.y < 1);
     renderPass.setUniform('lightScale', lightScale.x, lightScale.y);
     renderPass.setTexture('diffuseSpecularTex', light);
     renderPass.setTexture('positionTex', position);
+    renderPass.setTexture('normalTex', normal);
     renderPass.setTexture('diffuseSpecularAlbedoTex', diffuseSpecularAlbedo);
 
     renderPass.useProgram();

--- a/src/renderer/ToneMapPass.js
+++ b/src/renderer/ToneMapPass.js
@@ -37,6 +37,7 @@ export function makeToneMapPass(gl, params) {
       diffuseSpecularAlbedo,
       position,
       normal,
+      matProps,
     } = params;
 
     renderPass.setUniform('edgeAwareUpscale', lightScale.x < 1 || lightScale.y < 1);
@@ -44,6 +45,7 @@ export function makeToneMapPass(gl, params) {
     renderPass.setTexture('diffuseSpecularTex', light);
     renderPass.setTexture('positionTex', position);
     renderPass.setTexture('normalTex', normal);
+    renderPass.setTexture('matProps', matProps);
     renderPass.setTexture('diffuseSpecularAlbedoTex', diffuseSpecularAlbedo);
 
     renderPass.useProgram();

--- a/src/renderer/glsl/chunks/rayTraceCore.glsl
+++ b/src/renderer/glsl/chunks/rayTraceCore.glsl
@@ -1,8 +1,8 @@
 export default `
-  #define STANDARD 0
-  #define THIN_GLASS 1
-  #define THICK_GLASS 2
-  #define SHADOW_CATCHER 3
+  #define STANDARD 1
+  #define THIN_GLASS 2
+  #define THICK_GLASS 3
+  #define SHADOW_CATCHER 4
 
   const float IOR = 1.5;
   const float INV_IOR = 1.0 / IOR;

--- a/src/renderer/glsl/chunks/surfaceInteractionDirect.glsl
+++ b/src/renderer/glsl/chunks/surfaceInteractionDirect.glsl
@@ -7,18 +7,10 @@ export default `
   uniform sampler2D gMatProps;
 
   void surfaceInteractionDirect(vec2 coord, inout SurfaceInteraction si) {
-    vec4 positionAndMeshIndex = texture(gPosition, coord);
+    si.position = texture(gPosition, coord).xyz;
 
-    si.position = positionAndMeshIndex.xyz;
+    si.normal = normalize(texture(gNormal, coord).xyz);
 
-    float meshIndex = positionAndMeshIndex.w;
-
-    vec4 normalMaterialType = texture(gNormal, coord);
-
-    si.normal = normalize(normalMaterialType.xyz);
-    si.materialType = int(normalMaterialType.w);
-
-    vec4 faceNormalAndMaterialType = texture(gFaceNormal, coord);
 
     si.faceNormal = normalize(texture(gFaceNormal, coord).xyz);
 
@@ -27,7 +19,8 @@ export default `
     vec4 matProps = texture(gMatProps, coord);
     si.roughness = matProps.x;
     si.metalness = matProps.y;
+    si.materialType = int(matProps.z);
 
-    si.hit = meshIndex > 0.0 ? true : false;
+    si.hit = si.materialType > 0 ? true : false;
   }
 `;

--- a/src/renderer/glsl/chunks/surfaceInteractionDirect.glsl
+++ b/src/renderer/glsl/chunks/surfaceInteractionDirect.glsl
@@ -13,12 +13,12 @@ export default `
 
     float meshIndex = positionAndMeshIndex.w;
 
-    vec4 normalMaterialType = texture(gNormal, coord);
+    si.normal = normalize(texture(gNormal, coord).xyz);
 
-    si.normal = normalize(normalMaterialType.xyz);
-    si.materialType = int(normalMaterialType.w);
+    vec4 faceNormalAndMaterialType = texture(gNormal, coord);
 
-    si.faceNormal = normalize(texture(gFaceNormal, coord).xyz);
+    si.faceNormal = normalize(faceNormalAndMaterialType.xyz);
+    si.materialType = int(faceNormalAndMaterialType.w);
 
     si.albedo = vec3(1.0);
 

--- a/src/renderer/glsl/chunks/surfaceInteractionDirect.glsl
+++ b/src/renderer/glsl/chunks/surfaceInteractionDirect.glsl
@@ -13,12 +13,14 @@ export default `
 
     float meshIndex = positionAndMeshIndex.w;
 
-    si.normal = normalize(texture(gNormal, coord).xyz);
+    vec4 normalMaterialType = texture(gNormal, coord);
 
-    vec4 faceNormalAndMaterialType = texture(gNormal, coord);
+    si.normal = normalize(normalMaterialType.xyz);
+    si.materialType = int(normalMaterialType.w);
 
-    si.faceNormal = normalize(faceNormalAndMaterialType.xyz);
-    si.materialType = int(faceNormalAndMaterialType.w);
+    vec4 faceNormalAndMaterialType = texture(gFaceNormal, coord);
+
+    si.faceNormal = normalize(texture(gFaceNormal, coord).xyz);
 
     si.albedo = vec3(1.0);
 

--- a/src/renderer/glsl/gBuffer.frag
+++ b/src/renderer/glsl/gBuffer.frag
@@ -48,11 +48,11 @@ source: `
     #endif
 
     float positionDiff = max(length(dFdx(vPosition)), length(dFdy(vPosition)));
-    float normalDiff = max(length(dFdx(normal)), length(dFdy(normal)));
+    float normalDiff = max(length(dFdx(faceNormal)), length(dFdy(faceNormal)));
 
     out_position = vec4(vPosition, positionDiff);
-    out_normal = vec4(normal, normalDiff);
-    out_faceNormal = vec4(faceNormal, materialType);
+    out_normal = vec4(normal, materialType);
+    out_faceNormal = vec4(faceNormal, float(meshIndex) + EPS);
     out_albedo = vec4(albedo, 1.0);
     out_matProps = vec4(roughness, metalness, 0, 0);
   }

--- a/src/renderer/glsl/gBuffer.frag
+++ b/src/renderer/glsl/gBuffer.frag
@@ -12,6 +12,7 @@ source: `
   in vec3 vPosition;
   in vec3 vNormal;
   in vec2 vUv;
+  in vec4 vClipPos;
   flat in ivec2 vMaterialMeshIndex;
 
   vec3 faceNormals(vec3 pos) {
@@ -47,14 +48,15 @@ source: `
       normal = getMatNormal(materialIndex, uv, normal, dp1, dp2, duv1, duv2);
     #endif
 
-    float positionDiff = max(length(dFdx(vPosition)), length(dFdy(vPosition)));
-    float normalDiff = max(length(dFdx(faceNormal)), length(dFdy(faceNormal)));
+    float linearDepth = vClipPos.z;
+    float linearDiff = max(abs(dFdx(linearDepth)), abs(dFdy(linearDepth)));
+    float normalWidth = length(fwidth(normal));
 
-    out_position = vec4(vPosition, positionDiff);
-    out_normal = vec4(normal, materialType);
-    out_faceNormal = vec4(faceNormal, float(meshIndex) + EPS);
+    out_position = vec4(vPosition, linearDepth);
+    out_normal = vec4(normal, normalWidth);
+    out_faceNormal = vec4(faceNormal, normalWidth);
     out_albedo = vec4(albedo, 1.0);
-    out_matProps = vec4(roughness, metalness, 0, 0);
+    out_matProps = vec4(roughness, metalness, materialType, linearDiff);
   }
 `
 

--- a/src/renderer/glsl/gBuffer.frag
+++ b/src/renderer/glsl/gBuffer.frag
@@ -47,9 +47,12 @@ source: `
       normal = getMatNormal(materialIndex, uv, normal, dp1, dp2, duv1, duv2);
     #endif
 
-    out_position = vec4(vPosition, float(meshIndex) + EPS);
-    out_normal = vec4(normal, materialType);
-    out_faceNormal = vec4(faceNormal, 0);
+    float positionDiff = max(length(dFdx(vPosition)), length(dFdy(vPosition)));
+    float normalDiff = max(length(dFdx(normal)), length(dFdy(normal)));
+
+    out_position = vec4(vPosition, positionDiff);
+    out_normal = vec4(normal, normalDiff);
+    out_faceNormal = vec4(faceNormal, materialType);
     out_albedo = vec4(albedo, 1.0);
     out_matProps = vec4(roughness, metalness, 0, 0);
   }

--- a/src/renderer/glsl/gBuffer.vert
+++ b/src/renderer/glsl/gBuffer.vert
@@ -11,6 +11,7 @@ source: `
   out vec3 vPosition;
   out vec3 vNormal;
   out vec2 vUv;
+  out vec4 vClipPos;
   flat out ivec2 vMaterialMeshIndex;
 
   void main() {
@@ -18,7 +19,8 @@ source: `
     vNormal = aNormal;
     vUv = aUv;
     vMaterialMeshIndex = aMaterialMeshIndex;
-    gl_Position = projView * vec4(aPosition, 1);
+    vClipPos = projView * vec4(aPosition, 1);
+    gl_Position = vClipPos;
   }
 `
 }

--- a/src/renderer/glsl/reproject.frag
+++ b/src/renderer/glsl/reproject.frag
@@ -91,31 +91,6 @@ source: `
         sum += weight;
       }
 
-      // if (sum <= 0.0) {
-      //   // If all samples of bilinear fail, try a 3x3 box filter
-      //   hTexel = ivec2(hTexelf + 0.5);
-
-      //   for (int x = -1; x <= 1; x++) {
-      //     for (int y = -1; y <= 1; y++) {
-      //       ivec2 texel = hTexel + ivec2(x, y);
-      //       vec2 gCoord = (vec2(texel) + 0.5) * hSizeInv;
-
-      //       vec3 previousNormal = normalize(texture(previousNormalTex, gCoord).xyz);
-      //       float previousDepth = texture(previousPositionTex, gCoord).w;
-
-      //       float isValid =
-      //         abs(clipPos.z  - previousDepth) / (depthWidth + 0.001) > 1.0 ||
-      //         distance(previousNormal, currentNormal) / (normalWidth + 0.001) > 20.0 ||
-      //         any(greaterThanEqual(texel, hSize)) ? 0.0 : 1.0;
-
-      //       float weight = isValid;
-      //       diffuseHistory += weight * texelFetch(previousDiffuseSpecularTex, ivec3(texel, 0), 0);
-      //       specularHistory += weight * texelFetch(previousDiffuseSpecularTex, ivec3(texel, 1), 0);
-      //       sum += weight;
-      //     }
-      //   }
-      // }
-
       if (sum > 0.00001) {
         diffuseHistory /= sum;
         specularHistory /= sum;

--- a/src/renderer/glsl/reproject.frag
+++ b/src/renderer/glsl/reproject.frag
@@ -10,6 +10,7 @@ source: `
   uniform mediump sampler2D positionTex;
   uniform mediump sampler2D normalTex;
   uniform mediump sampler2D matPropsTex;
+
   uniform vec2 lightScale;
   uniform vec2 previousLightScale;
 
@@ -24,10 +25,6 @@ source: `
   vec2 project3Dto2D(vec3 position) {
     vec4 historyCoord = historyCamera * vec4(position, 1.0);
     return 0.5 * historyCoord.xy / historyCoord.w + 0.5;
-  }
-
-  float getMeshId(sampler2D meshIdTex, vec2 vCoord) {
-    return floor(texture(meshIdTex, vCoord).w);
   }
 
   void main() {
@@ -89,8 +86,8 @@ source: `
         int previousMeshId = int(previousNormalAndMeshId.w);
 
         float isValid =
-          distance(previousPosition, currentPosition) / posDiff > 0.003 ||
-          distance(previousNormal, currentNormal) > 1. ||
+          distance(previousPosition, currentPosition) / (posDiff + 0.001) > 0.005 ||
+          distance(previousNormal, currentNormal) > 1.0 ||
           previousMeshId != currentMeshId ||
           any(greaterThanEqual(texel[i], hSize)) ? 0.0 : 1.0;
 
@@ -115,8 +112,8 @@ source: `
       //       int previousMeshId = int(previousNormalAndMeshId.w);
 
       //       float isValid =
-      //         distance(previousPosition, currentPosition) / posDiff > 0.003 ||
-      //         distance(previousNormal, currentNormal) > 1. ||
+      //         distance(previousPosition, currentPosition) / (posDiff + 0.001) > 0.005 ||
+      //         // distance(previousNormal, currentNormal) > 1. ||
       //         previousMeshId != currentMeshId ||
       //         any(greaterThanEqual(texel, hSize)) ? 0.0 : 1.0;
 

--- a/src/renderer/glsl/toneMap.frag
+++ b/src/renderer/glsl/toneMap.frag
@@ -76,19 +76,20 @@ source: `
   void main() {
     Light light;
 
-    if (edgeAwareUpscale) {
-      light = getUpscaledLight();
-    } else {
+    // if (edgeAwareUpscale) {
+    //   light = getUpscaledLight();
+    // } else {
       light.diffuse = texture(diffuseSpecularTex, vec3(lightScale * vCoord, 0));
       light.specular = texture(diffuseSpecularTex, vec3(lightScale * vCoord, 1));
-    }
+    // }
 
     vec4 diffuseAlbedo = texture(diffuseSpecularAlbedoTex, vec3(vCoord, 0));
     vec4 specularAlbedo = texture(diffuseSpecularAlbedoTex, vec3(vCoord, 1));
 
     // alpha channel stores the number of samples progressively rendered
     // divide the sum of light by alpha to obtain average contribution of light
-    vec3 color = diffuseAlbedo.rgb * light.diffuse.rgb / light.diffuse.a + specularAlbedo.rgb * light.specular.rgb / light.specular.a;
+    // vec3 color = diffuseAlbedo.rgb * light.diffuse.rgb / light.diffuse.a + specularAlbedo.rgb * light.specular.rgb / light.specular.a;
+    vec3 color = light.diffuse.rgb / light.diffuse.a + light.specular.rgb / light.specular.a;
 
     // add background map to areas where geometry is not rendered
     vec3 direction = getCameraDirection(camera, vCoord);

--- a/src/renderer/glsl/toneMap.frag
+++ b/src/renderer/glsl/toneMap.frag
@@ -151,10 +151,10 @@ source: `
     // vec3 color = light.diffuse.rgb / light.diffuse.a + light.specular.rgb / light.specular.a;
 
     // add background map to areas where geometry is not rendered
-    // vec3 direction = getCameraDirection(camera, vCoord);
-    // vec2 backgroundUv = cartesianToEquirect(direction);
-    // vec3 background = texture(backgroundMap, backgroundUv).rgb;
-    // color += (1.0 - diffuseAlbedo.a) * background;
+    vec3 direction = getCameraDirection(camera, vCoord);
+    vec2 backgroundUv = cartesianToEquirect(direction);
+    vec3 background = texture(backgroundMap, backgroundUv).rgb;
+    color += (1.0 - diffuseAlbedo.a) * background;
 
     color *= EXPOSURE;
 

--- a/src/renderer/glsl/toneMap.frag
+++ b/src/renderer/glsl/toneMap.frag
@@ -11,15 +11,56 @@ source: `
 
   uniform mediump sampler2DArray diffuseSpecularTex;
   uniform mediump sampler2DArray diffuseSpecularAlbedoTex;
+
   uniform sampler2D positionTex;
+  uniform sampler2D normalTex;
 
   uniform vec2 lightScale;
   uniform bool edgeAwareUpscale;
 
   uniform sampler2D backgroundMap;
 
-  float getMeshId(sampler2D meshIdTex, vec2 vCoord) {
-    return floor(texture(meshIdTex, vCoord).w);
+    // from http://www.java-gaming.org/index.php?topic=35123.0
+  vec4 cubic(float v){
+      vec4 n = vec4(1.0, 2.0, 3.0, 4.0) - v;
+      vec4 s = n * n * n;
+      float x = s.x;
+      float y = s.y - 4.0 * s.x;
+      float z = s.z - 4.0 * s.y + 6.0 * s.x;
+      float w = 6.0 - x - y - z;
+      return vec4(x, y, z, w) * (1.0/6.0);
+  }
+
+  vec4 textureBicubic(sampler2DArray sampler, vec3 texCoordsAndIndex){
+
+    vec2 texSize = vec2(textureSize(sampler, 0));
+    vec2 invTexSize = 1.0 / texSize;
+
+    vec2 texCoords = texCoordsAndIndex.xy * texSize - 0.5;
+    float index = texCoordsAndIndex.z;
+
+    vec2 fxy = fract(texCoords);
+    texCoords -= fxy;
+
+    vec4 xcubic = cubic(fxy.x);
+    vec4 ycubic = cubic(fxy.y);
+
+    vec4 c = texCoords.xxyy + vec2 (-0.5, +1.5).xyxy;
+
+    vec4 s = vec4(xcubic.xz + xcubic.yw, ycubic.xz + ycubic.yw);
+    vec4 offset = c + vec4 (xcubic.yw, ycubic.yw) / s;
+
+    offset *= invTexSize.xxyy;
+
+    vec4 sample0 = texture(sampler, vec3(offset.xz, index));
+    vec4 sample1 = texture(sampler, vec3(offset.yz, index));
+    vec4 sample2 = texture(sampler, vec3(offset.xw, index));
+    vec4 sample3 = texture(sampler, vec3(offset.yw, index));
+
+    float sx = s.x / (s.x + s.y);
+    float sy = s.z / (s.z + s.w);
+
+    return mix(mix(sample3, sample2, sx), mix(sample1, sample0, sx), sy);
   }
 
   struct Light {
@@ -28,9 +69,17 @@ source: `
   };
 
   Light getUpscaledLight() {
-    float meshId = getMeshId(positionTex, vCoord);
+    vec2 bufferSize = vec2(textureSize(diffuseSpecularTex, 0));
 
-    vec2 sizef = lightScale * vec2(textureSize(positionTex, 0));
+    vec4 positionAndDiff = textureLinear(positionTex, vCoord);
+    vec3 currentPosition = positionAndDiff.xyz;
+    float posDiff = positionAndDiff.w * max(bufferSize.x, bufferSize.y);
+
+    vec4 normalAndMeshId = texture(normalTex, vCoord);
+    vec3 currentNormal = normalize(normalAndMeshId.xyz);
+    int currentMeshId = int(normalAndMeshId.w);
+
+    vec2 sizef = lightScale * bufferSize;
     vec2 texelf = vCoord * sizef - 0.5;
     ivec2 texel = ivec2(texelf);
     vec2 f = fract(texelf);
@@ -52,8 +101,19 @@ source: `
     Light light;
     float sum;
     for (int i = 0; i < 4; i++) {
-      vec2 pCoord = (vec2(texels[i]) + 0.5) / sizef;
-      float isValid = getMeshId(positionTex, pCoord) == meshId ? 1.0 : 0.0;
+      vec2 gCoord = (vec2(texels[i]) + 0.5) / sizef;
+
+      vec3 previousPosition = textureLinear(positionTex, gCoord).xyz;
+      vec4 previousNormalAndMeshId = texture(normalTex, gCoord);
+      vec3 previousNormal = normalize(previousNormalAndMeshId.xyz);
+      int previousMeshId = int(previousNormalAndMeshId.w);
+
+      float isValid =
+        distance(previousPosition, currentPosition) / (posDiff + 0.001) > 0.005 ||
+        distance(previousNormal, currentNormal) > 1.0 ||
+        previousMeshId != currentMeshId ||
+        false ? 0.0 : 1.0;
+
       float weight = isValid * weights[i];
       light.diffuse += weight * texelFetch(diffuseSpecularTex, ivec3(texels[i], 0), 0);
       light.specular += weight * texelFetch(diffuseSpecularTex, ivec3(texels[i], 1), 0);
@@ -76,20 +136,20 @@ source: `
   void main() {
     Light light;
 
-    // if (edgeAwareUpscale) {
-    //   light = getUpscaledLight();
-    // } else {
+    if (edgeAwareUpscale) {
+      light = getUpscaledLight();
+    } else {
       light.diffuse = texture(diffuseSpecularTex, vec3(lightScale * vCoord, 0));
       light.specular = texture(diffuseSpecularTex, vec3(lightScale * vCoord, 1));
-    // }
+    }
 
     vec4 diffuseAlbedo = texture(diffuseSpecularAlbedoTex, vec3(vCoord, 0));
     vec4 specularAlbedo = texture(diffuseSpecularAlbedoTex, vec3(vCoord, 1));
 
     // alpha channel stores the number of samples progressively rendered
     // divide the sum of light by alpha to obtain average contribution of light
-    // vec3 color = diffuseAlbedo.rgb * light.diffuse.rgb / light.diffuse.a + specularAlbedo.rgb * light.specular.rgb / light.specular.a;
-    vec3 color = light.diffuse.rgb / light.diffuse.a + light.specular.rgb / light.specular.a;
+    vec3 color = diffuseAlbedo.rgb * light.diffuse.rgb / light.diffuse.a + specularAlbedo.rgb * light.specular.rgb / light.specular.a;
+    // vec3 color = light.diffuse.rgb / light.diffuse.a + light.specular.rgb / light.specular.a;
 
     // add background map to areas where geometry is not rendered
     vec3 direction = getCameraDirection(camera, vCoord);

--- a/src/renderer/glsl/toneMap.frag
+++ b/src/renderer/glsl/toneMap.frag
@@ -21,49 +21,6 @@ source: `
 
   uniform sampler2D backgroundMap;
 
-    // from http://www.java-gaming.org/index.php?topic=35123.0
-  vec4 cubic(float v){
-      vec4 n = vec4(1.0, 2.0, 3.0, 4.0) - v;
-      vec4 s = n * n * n;
-      float x = s.x;
-      float y = s.y - 4.0 * s.x;
-      float z = s.z - 4.0 * s.y + 6.0 * s.x;
-      float w = 6.0 - x - y - z;
-      return vec4(x, y, z, w) * (1.0/6.0);
-  }
-
-  vec4 textureBicubic(sampler2DArray sampler, vec3 texCoordsAndIndex){
-
-    vec2 texSize = vec2(textureSize(sampler, 0));
-    vec2 invTexSize = 1.0 / texSize;
-
-    vec2 texCoords = texCoordsAndIndex.xy * texSize - 0.5;
-    float index = texCoordsAndIndex.z;
-
-    vec2 fxy = fract(texCoords);
-    texCoords -= fxy;
-
-    vec4 xcubic = cubic(fxy.x);
-    vec4 ycubic = cubic(fxy.y);
-
-    vec4 c = texCoords.xxyy + vec2 (-0.5, +1.5).xyxy;
-
-    vec4 s = vec4(xcubic.xz + xcubic.yw, ycubic.xz + ycubic.yw);
-    vec4 offset = c + vec4 (xcubic.yw, ycubic.yw) / s;
-
-    offset *= invTexSize.xxyy;
-
-    vec4 sample0 = texture(sampler, vec3(offset.xz, index));
-    vec4 sample1 = texture(sampler, vec3(offset.yz, index));
-    vec4 sample2 = texture(sampler, vec3(offset.xw, index));
-    vec4 sample3 = texture(sampler, vec3(offset.yw, index));
-
-    float sx = s.x / (s.x + s.y);
-    float sy = s.z / (s.z + s.w);
-
-    return mix(mix(sample3, sample2, sx), mix(sample1, sample0, sx), sy);
-  }
-
   struct Light {
     vec4 diffuse;
     vec4 specular;
@@ -147,7 +104,8 @@ source: `
     // alpha channel stores the number of samples progressively rendered
     // divide the sum of light by alpha to obtain average contribution of light
     vec3 color = diffuseAlbedo.rgb * light.diffuse.rgb / light.diffuse.a + specularAlbedo.rgb * light.specular.rgb / light.specular.a;
-    // vec3 color = light.diffuse.rgb;
+
+    // debug render without albedo
     // vec3 color = light.diffuse.rgb / light.diffuse.a + light.specular.rgb / light.specular.a;
 
     // add background map to areas where geometry is not rendered


### PR DESCRIPTION
## Brief Description
This PR modifies the temporal reprojection algorithm to closely resemble SVGF. Namely, instead of rejecting sample history if mesh IDs don't match, we instead reject sample history if the depth buffer or normal buffer don't match.

## Pull Request Guidelines
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] I have added pull requests labels which describe my contribution.
- [x] All existing tests passed.
    - [ ] I have added tests to cover my changes, of which pass.
- [x] I have [compared](https://github.com/hoverinc/ray-tracing-renderer/wiki/Contributing#comparing-changes) the render output of my branch to `master`.
- [x] My code has passed the ESLint configuration for this project.
- [ ] My change requires modifications to the documentation.
    - [ ] I have updated the documentation accordingly.
